### PR TITLE
fix: replace dangerous txtx install instructions with official docs

### DIFF
--- a/.github/workflows/deploy-devnet.yml
+++ b/.github/workflows/deploy-devnet.yml
@@ -75,16 +75,15 @@ jobs:
 
       - uses: actions/cache@v5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: cargo-txtx-${{ runner.os }}
+          path: ~/.txtx
+          key: txtx-${{ runner.os }}
 
       - name: Install txtx
         run: |
+          echo "$HOME/.txtx/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.txtx/bin:$PATH"
           if ! command -v txtx &> /dev/null; then
-            cargo install txtx
+            curl -sL https://install.txtx.sh/ | bash
           fi
 
       - name: Deploy to devnet

--- a/justfile
+++ b/justfile
@@ -59,12 +59,12 @@ build-client:
     cd clients/typescript && pnpm build
     cd examples/typescript/escrow-demo && pnpm install
 # ******************************************************************************
-# Deployment (requires txtx CLI: cargo install txtx)
+# Deployment (requires txtx CLI: https://docs.txtx.sh/install)
 # ******************************************************************************
 
 [private]
 check-txtx:
-    @command -v txtx >/dev/null 2>&1 || { echo "Error: txtx not found. Install with: cargo install txtx"; exit 1; }
+    @command -v txtx >/dev/null 2>&1 || { echo "Error: txtx not found. Install from: https://docs.txtx.sh/install"; exit 1; }
 
 # Deploy to devnet (supervised mode with web UI)
 deploy-devnet: check-txtx


### PR DESCRIPTION
## Summary

- Remove `cargo install txtx` command which pointed to unclaimed crates.io package (supply chain attack vector)
- Update `justfile` to reference official txtx documentation at https://docs.txtx.sh/install
- Update CI workflow to use official install script (`curl -sL https://install.txtx.sh/ | bash`)
- Update cache configuration to use `~/.txtx` instead of cargo directories

## Background

The real txtx tool (from txtx.sh) is NOT published on crates.io. The crates.io package name "txtx" was unclaimed, making it a supply chain vulnerability. Users following the old instructions would have installed an attacker-controlled package if someone had claimed the name.

## Test Plan

1. Verify error message is shown when txtx is not installed: `just check-txtx`
2. Review CI workflow changes to confirm proper installation method