### PR TITLE
ci: add program verification and idl deployment

### DIFF
--- a/.github/workflows/deploy-devnet.yml
+++ b/.github/workflows/deploy-devnet.yml
@@ -57,6 +57,12 @@ jobs:
           name: program-binary
           path: target/deploy/escrow_program.so
 
+      - name: Upload IDL
+        uses: actions/upload-artifact@v4
+        with:
+          name: idl
+          path: idl/escrow_program.json
+
   deploy:
     name: Deploy to Devnet
     needs: build
@@ -97,9 +103,37 @@ jobs:
           DEVNET_RPC_URL: ${{ secrets.DEVNET_RPC_URL }}
           DEPLOYER_SECRET_KEY: ${{ secrets.DEPLOYER_SECRET_KEY }}
 
+      - name: Download IDL
+        uses: actions/download-artifact@v4
+        with:
+          name: idl
+          path: idl/
+
+      - name: Install program-metadata CLI
+        run: cargo install program-metadata-cli
+
+      - name: Write deployer keypair
+        run: echo '${{ secrets.DEPLOYER_SECRET_KEY }}' > deployer.json
+
+      - name: Deploy IDL
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            program-metadata write idl Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg idl/escrow_program.json \
+              --keypair deployer.json \
+              --rpc ${{ secrets.DEVNET_RPC_URL }}
+
+      - name: Clean up keypair
+        if: always()
+        run: rm -f deployer.json
+
       - name: Deployment Summary
         if: success()
         run: |
           echo "## Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Program deployed to **devnet**" >> $GITHUB_STEP_SUMMARY
+          echo "IDL deployed on-chain via Program Metadata Program" >> $GITHUB_STEP_SUMMARY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "pinocchio-token",
  "pinocchio-token-2022",
  "serde_json",
+ "solana-security-txt",
  "spl-token-2022",
  "thiserror 2.0.17",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ pinocchio-token = "0.5.0"
 pinocchio-token-2022 = "^0.2.0"
 spl-token-2022 = { version = "^10.0.0", features = ["no-entrypoint"] }
 thiserror = "^2.0.17"
+solana-security-txt = "^1.1.2"
 borsh = "^1.6.0"
 num-derive = "^0.4.0"
 num-traits = "^0.2.0"

--- a/justfile
+++ b/justfile
@@ -79,6 +79,45 @@ deploy-localnet: check-txtx
     txtx run deploy --env localnet
 
 # ******************************************************************************
+# IDL Deployment (uses Program Metadata Program)
+# ******************************************************************************
+
+[private]
+check-program-metadata:
+    @command -v program-metadata >/dev/null 2>&1 || { echo "Error: program-metadata not installed. See https://github.com/solana-program/program-metadata"; exit 1; }
+
+# Deploy IDL to devnet
+deploy-idl-devnet: check-program-metadata
+    program-metadata write idl Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg idl/escrow_program.json \
+        --keypair .keypairs/escrow-devnet-deployer.json \
+        --rpc https://api.devnet.solana.com
+
+# Deploy IDL to mainnet
+deploy-idl-mainnet: check-program-metadata
+    program-metadata write idl Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg idl/escrow_program.json \
+        --keypair .keypairs/escrow-mainnet-deployer.json \
+        --rpc https://api.mainnet-beta.solana.com
+
+# ******************************************************************************
+# Build Verification (uses solana-verify CLI)
+# ******************************************************************************
+
+[private]
+check-solana-verify:
+    @command -v solana-verify >/dev/null 2>&1 || { echo "Error: solana-verify not installed. Run: cargo install solana-verify"; exit 1; }
+
+# Verify mainnet deployment against repo (remote build via OtterSec)
+# Note: Remote verification (--remote) only works on mainnet
+verify-mainnet: check-solana-verify
+    solana-verify verify-from-repo \
+        https://github.com/solana-program/escrow \
+        --program-id Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg \
+        --library-name escrow_program \
+        --mount-path program \
+        --remote \
+        -um
+
+# ******************************************************************************
 # Release
 # ******************************************************************************
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -25,6 +25,7 @@ pinocchio-token = { workspace = true }
 pinocchio-token-2022 = { workspace = true }
 spl-token-2022 = { workspace = true }
 thiserror = { workspace = true }
+solana-security-txt = { workspace = true }
 
 [build-dependencies]
 codama = { workspace = true }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -30,3 +30,15 @@ pub mod state;
 pub mod entrypoint;
 
 declare_id!("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg");
+
+#[cfg(not(feature = "no-entrypoint"))]
+use solana_security_txt::security_txt;
+
+#[cfg(not(feature = "no-entrypoint"))]
+security_txt! {
+    name: "Escrow Program",
+    project_url: "https://github.com/solana-program/escrow",
+    contacts: "link:https://github.com/solana-program/escrow/security/advisories/new",
+    policy: "https://github.com/solana-program/escrow/security/policy",
+    source_code: "https://github.com/solana-program/escrow"
+}


### PR DESCRIPTION
## Summary

- Add automated IDL deployment to devnet CI workflow using Program Metadata Program
- Add justfile targets for manual IDL deployment to devnet/mainnet
- Add justfile target for mainnet build verification via solana-verify
- Add solana-security-txt metadata to program binary for security contact info

## Test Plan

The CI workflow will automatically deploy the IDL after program deployment on devnet. For manual testing:

```bash
# Test IDL deployment (requires program-metadata CLI)
just deploy-idl-devnet

# Test build verification (mainnet only, requires solana-verify CLI)
just verify-mainnet
```