### PR TITLE
fix(codama): use PDA defaults instead of hardcoded public keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,6 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.1.0",
  "thiserror 2.0.18",
 ]
 
@@ -4209,15 +4208,15 @@ dependencies = [
 
 [[package]]
 name = "solana-cpi"
-version = "3.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dea26709d867aada85d0d3617db0944215c8bb28d3745b912de7db13a23280c"
+checksum = "16238feb63d1cbdf915fb287f29ef7a7ebf81469bd6214f8b72a53866b593f8f"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 3.0.0",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 3.0.0",
  "solana-stable-layout",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ pinocchio-token-2022 = "^0.2.0"
 spl-token-2022 = { version = "^10.0.0", features = ["no-entrypoint"] }
 thiserror = "^2.0.17"
 solana-security-txt = "^1.1.2"
-borsh = "^1.6.0"
+borsh = { version = "^1.6.0", features = ["derive"] }
 num-derive = "^0.4.0"
 num-traits = "^0.2.0"

--- a/apps/web/src/components/instructions/UpdateAdmin.tsx
+++ b/apps/web/src/components/instructions/UpdateAdmin.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import type { Address } from '@solana/kit';
 import { Badge } from '@solana/design-system/badge';
-import { getUpdateAdminInstruction } from '@solana/escrow-program-client';
+import { getUpdateAdminInstructionAsync } from '@solana/escrow-program-client';
 import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
 import { useWallet } from '@/contexts/WalletContext';
@@ -33,7 +33,7 @@ export function UpdateAdmin() {
             return;
         }
 
-        const ix = getUpdateAdminInstruction(
+        const ix = await getUpdateAdminInstructionAsync(
             {
                 admin: signer,
                 newAdmin: signer,

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -8,11 +8,10 @@ repository = "https://github.com/solana-program/escrow"
 
 [dependencies]
 borsh = { workspace = true }
-solana-account-info = "3.1.0"
-solana-pubkey = "4.0.0"
-solana-address = "2.0.0"
-solana-instruction = "3.1.0"
-solana-cpi = "3.0.1"
+solana-account-info = "~3.1"
+solana-address = { version = "~2.2", features = ["borsh", "copy", "curve25519", "decode"] }
+solana-instruction = "~3.1"
+solana-cpi = "~3.0"
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 

--- a/idl/escrow_program.json
+++ b/idl/escrow_program.json
@@ -761,8 +761,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -773,13 +777,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -895,8 +896,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -907,13 +912,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -1038,8 +1040,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -1050,13 +1056,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -1360,8 +1363,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -1372,13 +1379,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -1490,8 +1494,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -1502,13 +1510,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -1734,8 +1739,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -1746,13 +1755,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -1970,8 +1976,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -1982,13 +1992,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -2121,8 +2128,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -2133,13 +2144,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -2242,8 +2250,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "docs": [
               "Event authority PDA for CPI event emission"
@@ -2254,13 +2266,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
             "docs": [
-              "Escrow program for CPI event emission"
+              "Escrow Program ID (this program)"
             ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",
@@ -2376,8 +2385,12 @@
           },
           {
             "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M"
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "eventAuthority"
+              },
+              "seeds": []
             },
             "isSigner": false,
             "isWritable": false,

--- a/idl/escrow_program.json
+++ b/idl/escrow_program.json
@@ -2398,10 +2398,10 @@
             "name": "eventAuthority"
           },
           {
-            "defaultValue": {
-              "kind": "publicKeyValueNode",
-              "publicKey": "Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg"
-            },
+            "docs": [
+              "Escrow Program ID (this program)"
+            ],
+            "isOptional": true,
             "isSigner": false,
             "isWritable": false,
             "kind": "instructionAccountNode",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "devDependencies": {
         "@codama/nodes-from-anchor": "^1.3.8",
         "@codama/renderers-js": "^1.7.0",
-        "@codama/renderers-rust": "^1.2.9",
+        "@codama/renderers-rust": "^3.0.0",
         "@eslint/js": "^9.39.2",
         "@jest/globals": "^30.2.0",
         "@solana-program/system": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@codama/renderers-rust':
-        specifier: ^1.2.9
-        version: 1.2.9(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: file:/Users/sf-am/SF/Ecosystem/renderers-rust
+        version: file:../../Ecosystem/renderers-rust(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
@@ -466,8 +466,8 @@ packages:
     resolution: {integrity: sha512-WwKkSkNPdUBVWjGmkG+RNXyZ5K/4ji8UZQGzowDNTrqktUrqPsBThOkc7Zpmv+TpCapxrfjj0Txpo+0q5FjKGw==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/renderers-rust@1.2.9':
-    resolution: {integrity: sha512-6sc/g8LYHEa3MFqakEBRJito/1liv1jE1b6P1gGRz7z84YiGscPKh0pbcELlLPxyLraNTBYSA6V9EXrj2LLvIA==}
+  '@codama/renderers-rust@file:../../Ecosystem/renderers-rust':
+    resolution: {directory: ../../Ecosystem/renderers-rust, type: directory}
     engines: {node: '>=20.18.0'}
 
   '@codama/validators@1.5.0':
@@ -764,6 +764,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -7757,14 +7760,16 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/renderers-rust@1.2.9(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/renderers-rust@file:../../Ecosystem/renderers-rust(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@codama/errors': 1.5.0
       '@codama/nodes': 1.5.0
       '@codama/renderers-core': 1.3.5
       '@codama/visitors-core': 1.5.0
-      '@solana/codecs-strings': 5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@iarna/toml': 2.2.5
+      '@solana/codecs-strings': 6.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       nunjucks: 3.2.4
+      semver: 7.7.3
     transitivePeerDependencies:
       - chokidar
       - fastestsmallesttextencoderdecoder
@@ -8015,6 +8020,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iarna/toml@2.2.5': {}
 
   '@img/colour@1.1.0':
     optional: true

--- a/program/src/instructions/definition.rs
+++ b/program/src/instructions/definition.rs
@@ -281,10 +281,7 @@ pub enum EscrowProgramInstruction {
         name = "event_authority",
         default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     SetArbiter {
         /// Bump for extensions PDA
         #[codama(default_value = account_bump("extensions"))]

--- a/program/src/instructions/definition.rs
+++ b/program/src/instructions/definition.rs
@@ -20,13 +20,8 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
-    ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+        default_value = pda("event_authority", [])    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     CreatesEscrow {
         /// Bump for the escrow PDA
         #[codama(default_value = account_bump("escrow"))]
@@ -47,13 +42,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     AddTimelock {
         /// Bump for extensions PDA
         #[codama(default_value = account_bump("extensions"))]
@@ -76,13 +67,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     SetHook {
         /// Bump for extensions PDA
         #[codama(default_value = account_bump("extensions"))]
@@ -130,13 +117,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     #[codama(account(
         name = "extensions",
         docs = "Extensions PDA for escrow configuration",
@@ -157,13 +140,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     UpdateAdmin {} = 4,
 
     /// Withdraw tokens from an escrow vault back to the original depositor.
@@ -194,13 +173,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     Withdraw {} = 5,
 
     /// Allow a token mint for deposits into an escrow.
@@ -236,13 +211,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     AllowMint {
         /// Bump for the allowed_mint PDA
         #[codama(default_value = account_bump("allowedMint"))]
@@ -264,13 +235,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     BlockMint {} = 7,
 
     /// Block a token extension for an escrow.
@@ -287,13 +254,9 @@ pub enum EscrowProgramInstruction {
     #[codama(account(
         name = "event_authority",
         docs = "Event authority PDA for CPI event emission",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
-    #[codama(account(
-        name = "escrow_program",
-        docs = "Escrow program for CPI event emission",
-        default_value = public_key("Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg")
-    ))]
+    #[codama(account(name = "escrow_program", optional, docs = "Escrow Program ID (this program)"))]
     BlockTokenExtension {
         /// Bump for extensions PDA
         #[codama(default_value = account_bump("extensions"))]
@@ -316,7 +279,7 @@ pub enum EscrowProgramInstruction {
     #[codama(account(name = "system_program", default_value = program("system")))]
     #[codama(account(
         name = "event_authority",
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
     #[codama(account(
         name = "escrow_program",
@@ -334,7 +297,7 @@ pub enum EscrowProgramInstruction {
         name = "event_authority",
         docs = "Event authority PDA that must sign via CPI",
         signer,
-        default_value = public_key("Eq63FWYo9DXgwoTnpK9gjp7BH4PyhSPo11zEF9FK7f4M")
+        default_value = pda("event_authority", [])
     ))]
     EmitEvent {} = 228,
 }

--- a/scripts/generate-clients.ts
+++ b/scripts/generate-clients.ts
@@ -24,8 +24,7 @@ const configPreserver = preserveConfigFiles(typescriptClientsDir, rustClientsDir
 
 // Generate Rust client
 void escrowCodama.accept(
-    renderRustVisitor(path.join(rustClientsDir, 'src', 'generated'), {
-        crateFolder: rustClientsDir,
+    renderRustVisitor(rustClientsDir, {
         deleteFolderBeforeRendering: true,
         formatCode: true,
     }),


### PR DESCRIPTION
## Summary
- Replace hardcoded `public_key("Eq63FW...")` default for `event_authority` with `pda("event_authority", [])` across all instructions
- Replace hardcoded `public_key("Escrowae7...")` default for `escrow_program` with `optional` marker across all instructions
- Regenerated IDL to reflect the updated Codama attributes

## Test plan
- [x] `just build` passes
- [x] 179 integration tests pass
- [x] IDL regenerated and included