### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-patch-days: 0
+      semver-patch-days: 1
     groups:
       cargo-non-major:
         applies-to: version-updates
@@ -22,7 +22,7 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-patch-days: 0
+      semver-patch-days: 1
     groups:
       npm-non-major:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directory: "/"
+    directory: '/'
     schedule:
       interval: daily
     open-pull-requests-limit: 10
@@ -16,7 +16,7 @@ updates:
           - patch
 
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: daily
     open-pull-requests-limit: 10
@@ -31,10 +31,10 @@ updates:
           - patch
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     groups:
       actions:
         patterns:
-          - "*"
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-patch-days: 0
+    groups:
+      cargo-non-major:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-patch-days: 0
+    groups:
+      npm-non-major:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` enabling daily cargo + npm version updates and weekly github-actions updates
- Groups minor/patch into single PRs per ecosystem to reduce review noise
- 7-day `cooldown` (0 for patches) reduces day-zero malicious release exposure; security updates not delayed
- `package-ecosystem: npm` auto-detects pnpm via `pnpm-lock.yaml`

## Test plan
- [ ] Dependabot picks up config on merge (visible under repo `Insights → Dependency graph → Dependabot`)
- [ ] First scheduled scan opens grouped PRs within 24h