### PR TITLE
feat(web): add escrow data flows

### DIFF
--- a/apps/web/src/components/instructions/AddTimelock.tsx
+++ b/apps/web/src/components/instructions/AddTimelock.tsx
@@ -11,13 +11,27 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress, validatePositiveInteger } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function AddTimelock() {
+interface AddTimelockProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialLockDuration?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function AddTimelock({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialLockDuration = '',
+    onSuccess,
+    submitLabel,
+}: AddTimelockProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [lockDuration, setLockDuration] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [lockDuration, setLockDuration] = useState(initialLockDuration);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -51,6 +65,7 @@ export function AddTimelock() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -61,15 +76,17 @@ export function AddTimelock() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrow PDA address"
+                    required
+                />
+            )}
             <FormField
                 label="Lock Duration (seconds)"
                 value={lockDuration}
@@ -78,7 +95,7 @@ export function AddTimelock() {
                 type="number"
                 required
             />
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/AddTimelock.tsx
+++ b/apps/web/src/components/instructions/AddTimelock.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
-import { getAddTimelockInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress, validatePositiveInteger } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -26,20 +22,16 @@ export function AddTimelock({
     onSuccess,
     submitLabel,
 }: AddTimelockProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { addTimelock } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [lockDuration, setLockDuration] = useState(initialLockDuration);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        addTimelock.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(
             validateAddress(escrow, 'Escrow address'),
@@ -50,23 +42,16 @@ export function AddTimelock({
             return;
         }
 
-        const ix = await getAddTimelockInstructionAsync(
-            {
-                admin: signer,
-                escrow: escrow as Address,
+        const result = await addTimelock
+            .mutateAsync({
+                escrow,
                 lockDuration: BigInt(lockDuration),
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Add Timelock',
-            values: { escrow, lockDuration },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+            })
+            .catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -95,8 +80,8 @@ export function AddTimelock({
                 type="number"
                 required
             />
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={addTimelock.isPending} label={submitLabel} />
+            <TxResult signature={addTimelock.data?.signature} error={formError ?? addTimelock.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/AllowMint.tsx
+++ b/apps/web/src/components/instructions/AllowMint.tsx
@@ -11,13 +11,27 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function AllowMint() {
+interface AllowMintProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialMint?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function AllowMint({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialMint = '',
+    onSuccess,
+    submitLabel,
+}: AllowMintProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, defaultMint, rememberEscrow, rememberMint } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [mint, setMint] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [mint, setMint] = useState(initialMint);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -52,6 +66,7 @@ export function AllowMint() {
         if (txSignature) {
             rememberEscrow(escrow);
             rememberMint(mint);
+            onSuccess?.();
         }
     };
 
@@ -62,25 +77,29 @@ export function AllowMint() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
-            <FormField
-                label="Mint Address"
-                value={mint}
-                onChange={setMint}
-                autoFillValue={defaultMint}
-                onAutoFill={setMint}
-                placeholder="SPL token mint to allow"
-                required
-            />
-            <SendButton sending={sending} />
+            {!hideKnownFields && (
+                <>
+                    <FormField
+                        label="Escrow Address"
+                        value={escrow}
+                        onChange={setEscrow}
+                        autoFillValue={defaultEscrow}
+                        onAutoFill={setEscrow}
+                        placeholder="Escrow PDA address"
+                        required
+                    />
+                    <FormField
+                        label="Mint Address"
+                        value={mint}
+                        onChange={setMint}
+                        autoFillValue={defaultMint}
+                        onAutoFill={setMint}
+                        placeholder="SPL token mint to allow"
+                        required
+                    />
+                </>
+            )}
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/AllowMint.tsx
+++ b/apps/web/src/components/instructions/AllowMint.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
-import { getAllowMintInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -26,20 +22,16 @@ export function AllowMint({
     onSuccess,
     submitLabel,
 }: AllowMintProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { allowMint } = useEscrowMutations();
     const { defaultEscrow, defaultMint, rememberEscrow, rememberMint } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [mint, setMint] = useState(initialMint);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        allowMint.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(
             validateAddress(escrow, 'Escrow address'),
@@ -50,24 +42,12 @@ export function AllowMint({
             return;
         }
 
-        const ix = await getAllowMintInstructionAsync(
-            {
-                admin: signer,
-                escrow: escrow as Address,
-                mint: mint as Address,
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Allow Mint',
-            values: { escrow, mint },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            rememberMint(mint);
-            onSuccess?.();
-        }
+        const result = await allowMint.mutateAsync({ escrow, mint }).catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        rememberMint(mint);
+        onSuccess?.();
     };
 
     return (
@@ -99,8 +79,8 @@ export function AllowMint({
                     />
                 </>
             )}
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={allowMint.isPending} label={submitLabel} />
+            <TxResult signature={allowMint.data?.signature} error={formError ?? allowMint.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/BlockMint.tsx
+++ b/apps/web/src/components/instructions/BlockMint.tsx
@@ -11,14 +11,30 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress, validateOptionalAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function BlockMint() {
+interface BlockMintProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialMint?: string;
+    initialRentRecipient?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function BlockMint({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialMint = '',
+    initialRentRecipient = '',
+    onSuccess,
+    submitLabel,
+}: BlockMintProps = {}) {
     const { account, createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, defaultMint, rememberEscrow, rememberMint } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [mint, setMint] = useState('');
-    const [rentRecipient, setRentRecipient] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [mint, setMint] = useState(initialMint);
+    const [rentRecipient, setRentRecipient] = useState(initialRentRecipient);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -54,6 +70,7 @@ export function BlockMint() {
         if (txSignature) {
             rememberEscrow(escrow);
             rememberMint(mint);
+            onSuccess?.();
         }
     };
 
@@ -64,24 +81,28 @@ export function BlockMint() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
-            <FormField
-                label="Mint Address"
-                value={mint}
-                onChange={setMint}
-                autoFillValue={defaultMint}
-                onAutoFill={setMint}
-                placeholder="SPL token mint to block"
-                required
-            />
+            {!hideKnownFields && (
+                <>
+                    <FormField
+                        label="Escrow Address"
+                        value={escrow}
+                        onChange={setEscrow}
+                        autoFillValue={defaultEscrow}
+                        onAutoFill={setEscrow}
+                        placeholder="Escrow PDA address"
+                        required
+                    />
+                    <FormField
+                        label="Mint Address"
+                        value={mint}
+                        onChange={setMint}
+                        autoFillValue={defaultMint}
+                        onAutoFill={setMint}
+                        placeholder="SPL token mint to block"
+                        required
+                    />
+                </>
+            )}
             <FormField
                 label="Rent Recipient"
                 value={rentRecipient}
@@ -89,7 +110,7 @@ export function BlockMint() {
                 placeholder={account?.address ?? 'Defaults to connected wallet'}
                 hint="Address that receives rent from the closed allowed-mint account"
             />
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/BlockMint.tsx
+++ b/apps/web/src/components/instructions/BlockMint.tsx
@@ -1,12 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
-import { getBlockMintInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
 import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress, validateOptionalAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -28,10 +25,9 @@ export function BlockMint({
     onSuccess,
     submitLabel,
 }: BlockMintProps = {}) {
-    const { account, createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { account } = useWallet();
+    const { blockMint } = useEscrowMutations();
     const { defaultEscrow, defaultMint, rememberEscrow, rememberMint } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [mint, setMint] = useState(initialMint);
     const [rentRecipient, setRentRecipient] = useState(initialRentRecipient);
@@ -39,10 +35,8 @@ export function BlockMint({
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        blockMint.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(
             validateAddress(escrow, 'Escrow address'),
@@ -54,24 +48,12 @@ export function BlockMint({
             return;
         }
 
-        const ix = await getBlockMintInstructionAsync(
-            {
-                admin: signer,
-                escrow: escrow as Address,
-                mint: mint as Address,
-                rentRecipient: (rentRecipient || signer.address) as Address,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Block Mint',
-            values: { escrow, mint, rentRecipient: rentRecipient || account?.address || '' },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            rememberMint(mint);
-            onSuccess?.();
-        }
+        const result = await blockMint.mutateAsync({ escrow, mint, rentRecipient }).catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        rememberMint(mint);
+        onSuccess?.();
     };
 
     return (
@@ -110,8 +92,8 @@ export function BlockMint({
                 placeholder={account?.address ?? 'Defaults to connected wallet'}
                 hint="Address that receives rent from the closed allowed-mint account"
             />
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={blockMint.isPending} label={submitLabel} />
+            <TxResult signature={blockMint.data?.signature} error={formError ?? blockMint.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/BlockTokenExtension.tsx
+++ b/apps/web/src/components/instructions/BlockTokenExtension.tsx
@@ -22,13 +22,27 @@ const EXTENSION_OPTIONS = [
     { label: 'MetadataPointer (18)', value: '18' },
 ];
 
-export function BlockTokenExtension() {
+interface BlockTokenExtensionProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialExtensionType?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function BlockTokenExtension({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialExtensionType = '5',
+    onSuccess,
+    submitLabel,
+}: BlockTokenExtensionProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [extensionType, setExtensionType] = useState('5');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [extensionType, setExtensionType] = useState(initialExtensionType);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -64,6 +78,7 @@ export function BlockTokenExtension() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -74,15 +89,17 @@ export function BlockTokenExtension() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrow PDA address"
+                    required
+                />
+            )}
             <SelectField
                 label="Extension Type"
                 value={extensionType}
@@ -90,7 +107,7 @@ export function BlockTokenExtension() {
                 options={EXTENSION_OPTIONS}
                 hint="SPL Token-2022 extension type to block from deposits"
             />
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/BlockTokenExtension.tsx
+++ b/apps/web/src/components/instructions/BlockTokenExtension.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
-import { findExtensionsPda, getBlockTokenExtensionInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SelectField, SendButton } from './shared';
@@ -37,20 +33,16 @@ export function BlockTokenExtension({
     onSuccess,
     submitLabel,
 }: BlockTokenExtensionProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { blockTokenExtension } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [extensionType, setExtensionType] = useState(initialExtensionType);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        blockTokenExtension.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(validateAddress(escrow, 'Escrow address'));
         if (validationError) {
@@ -58,28 +50,13 @@ export function BlockTokenExtension({
             return;
         }
 
-        const [, extensionsBump] = await findExtensionsPda(
-            { escrow: escrow as Address },
-            { programAddress: programId as Address },
-        );
-        const ix = await getBlockTokenExtensionInstructionAsync(
-            {
-                admin: signer,
-                escrow: escrow as Address,
-                blockedExtension: Number(extensionType),
-                extensionsBump,
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Block Token Extension',
-            values: { escrow },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        const result = await blockTokenExtension
+            .mutateAsync({ escrow, extensionType: Number(extensionType) })
+            .catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -107,8 +84,8 @@ export function BlockTokenExtension({
                 options={EXTENSION_OPTIONS}
                 hint="SPL Token-2022 extension type to block from deposits"
             />
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={blockTokenExtension.isPending} label={submitLabel} />
+            <TxResult signature={blockTokenExtension.data?.signature} error={formError ?? blockTokenExtension.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/CreateEscrow.tsx
+++ b/apps/web/src/components/instructions/CreateEscrow.tsx
@@ -1,12 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { generateKeyPairSigner, type Address } from '@solana/kit';
-import { findEscrowPda, getCreatesEscrowInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
 import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { FormField, SendButton } from './shared';
 
@@ -16,43 +13,23 @@ interface CreateEscrowProps {
 }
 
 export function CreateEscrow({ onSuccess, submitLabel }: CreateEscrowProps = {}) {
-    const { account, createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { account } = useWallet();
+    const { createEscrow } = useEscrowMutations();
     const { rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [generatedSeed, setGeneratedSeed] = useState('');
     const [generatedEscrow, setGeneratedEscrow] = useState('');
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
-        const signer = createSigner();
-        if (!signer) return;
+        createEscrow.reset();
 
-        const escrowSeed = await generateKeyPairSigner();
-        setGeneratedSeed(escrowSeed.address);
-        const [escrow] = await findEscrowPda(
-            { escrowSeed: escrowSeed.address },
-            { programAddress: programId as Address },
-        );
-        setGeneratedEscrow(escrow);
+        const result = await createEscrow.mutateAsync().catch(() => null);
+        if (!result) return;
 
-        const ix = await getCreatesEscrowInstructionAsync(
-            {
-                admin: signer,
-                escrowSeed,
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Create Escrow',
-            values: { escrow },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        setGeneratedSeed(result.seed);
+        setGeneratedEscrow(result.escrow);
+        rememberEscrow(result.escrow);
+        onSuccess?.();
     };
 
     return (
@@ -88,8 +65,8 @@ export function CreateEscrow({ onSuccess, submitLabel }: CreateEscrowProps = {})
                     hint="Saved as the default escrow when creation succeeds"
                 />
             )}
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={error} />
+            <SendButton sending={createEscrow.isPending} label={submitLabel} />
+            <TxResult signature={createEscrow.data?.signature} error={createEscrow.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/CreateEscrow.tsx
+++ b/apps/web/src/components/instructions/CreateEscrow.tsx
@@ -10,7 +10,12 @@ import { useProgramContext } from '@/contexts/ProgramContext';
 import { TxResult } from '@/components/TxResult';
 import { FormField, SendButton } from './shared';
 
-export function CreateEscrow() {
+interface CreateEscrowProps {
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function CreateEscrow({ onSuccess, submitLabel }: CreateEscrowProps = {}) {
     const { account, createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { rememberEscrow } = useSavedValues();
@@ -46,6 +51,7 @@ export function CreateEscrow() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -82,7 +88,7 @@ export function CreateEscrow() {
                     hint="Saved as the default escrow when creation succeeds"
                 />
             )}
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={error} />
         </form>
     );

--- a/apps/web/src/components/instructions/Deposit.tsx
+++ b/apps/web/src/components/instructions/Deposit.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { generateKeyPairSigner, type Address } from '@solana/kit';
-import { findReceiptPda, getDepositInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress, validatePositiveInteger } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -28,10 +24,8 @@ export function Deposit({
     onSuccess,
     submitLabel,
 }: DepositProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { deposit } = useEscrowMutations();
     const { defaultEscrow, defaultMint, rememberEscrow, rememberMint, rememberReceipt } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [mint, setMint] = useState(initialMint);
     const [amount, setAmount] = useState(initialAmount);
@@ -41,10 +35,8 @@ export function Deposit({
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        deposit.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(
             validateAddress(escrow, 'Escrow address'),
@@ -56,41 +48,21 @@ export function Deposit({
             return;
         }
 
-        const receiptSeed = await generateKeyPairSigner();
-        setGeneratedSeed(receiptSeed.address);
-        const signerAddress = signer.address as Address;
-        const [receipt] = await findReceiptPda(
-            {
-                escrow: escrow as Address,
-                depositor: signerAddress,
-                mint: mint as Address,
-                receiptSeed: receiptSeed.address,
-            },
-            { programAddress: programId as Address },
-        );
-        setGeneratedReceipt(receipt);
-
-        const ix = await getDepositInstructionAsync(
-            {
-                depositor: signer,
-                escrow: escrow as Address,
-                mint: mint as Address,
+        const result = await deposit
+            .mutateAsync({
                 amount: BigInt(amount),
-                receiptSeed,
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Deposit',
-            values: { escrow, mint, receipt, amount },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            rememberMint(mint);
-            rememberReceipt(receipt);
-            onSuccess?.();
-        }
+                escrow,
+                mint,
+            })
+            .catch(() => null);
+        if (!result) return;
+
+        setGeneratedSeed(result.receiptSeed);
+        setGeneratedReceipt(result.receipt);
+        rememberEscrow(result.escrow);
+        rememberMint(result.mint);
+        rememberReceipt(result.receipt);
+        onSuccess?.();
     };
 
     return (
@@ -149,8 +121,8 @@ export function Deposit({
                     hint="Saved as the default receipt when deposit succeeds"
                 />
             )}
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={deposit.isPending} label={submitLabel} />
+            <TxResult signature={deposit.data?.signature} error={formError ?? deposit.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/Deposit.tsx
+++ b/apps/web/src/components/instructions/Deposit.tsx
@@ -11,14 +11,30 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress, validatePositiveInteger } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function Deposit() {
+interface DepositProps {
+    hideKnownFields?: boolean;
+    initialAmount?: string;
+    initialEscrow?: string;
+    initialMint?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function Deposit({
+    hideKnownFields = false,
+    initialAmount = '',
+    initialEscrow = '',
+    initialMint = '',
+    onSuccess,
+    submitLabel,
+}: DepositProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, defaultMint, rememberEscrow, rememberMint, rememberReceipt } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [mint, setMint] = useState('');
-    const [amount, setAmount] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [mint, setMint] = useState(initialMint);
+    const [amount, setAmount] = useState(initialAmount);
     const [generatedSeed, setGeneratedSeed] = useState('');
     const [generatedReceipt, setGeneratedReceipt] = useState('');
     const [formError, setFormError] = useState<string | null>(null);
@@ -73,6 +89,7 @@ export function Deposit() {
             rememberEscrow(escrow);
             rememberMint(mint);
             rememberReceipt(receipt);
+            onSuccess?.();
         }
     };
 
@@ -83,24 +100,28 @@ export function Deposit() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
-            <FormField
-                label="Mint Address"
-                value={mint}
-                onChange={setMint}
-                autoFillValue={defaultMint}
-                onAutoFill={setMint}
-                placeholder="SPL token mint address"
-                required
-            />
+            {!hideKnownFields && (
+                <>
+                    <FormField
+                        label="Escrow Address"
+                        value={escrow}
+                        onChange={setEscrow}
+                        autoFillValue={defaultEscrow}
+                        onAutoFill={setEscrow}
+                        placeholder="Escrow PDA address"
+                        required
+                    />
+                    <FormField
+                        label="Mint Address"
+                        value={mint}
+                        onChange={setMint}
+                        autoFillValue={defaultMint}
+                        onAutoFill={setMint}
+                        placeholder="SPL token mint address"
+                        required
+                    />
+                </>
+            )}
             <FormField
                 label="Amount (in base units)"
                 value={amount}
@@ -128,7 +149,7 @@ export function Deposit() {
                     hint="Saved as the default receipt when deposit succeeds"
                 />
             )}
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/RemoveExtension.tsx
+++ b/apps/web/src/components/instructions/RemoveExtension.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
-import { getRemoveExtensionInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SelectField, SendButton } from './shared';
@@ -33,20 +29,16 @@ export function RemoveExtension({
     onSuccess,
     submitLabel,
 }: RemoveExtensionProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { removeExtension } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [extensionType, setExtensionType] = useState(initialExtensionType);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        removeExtension.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(validateAddress(escrow, 'Escrow address'));
         if (validationError) {
@@ -54,23 +46,13 @@ export function RemoveExtension({
             return;
         }
 
-        const ix = await getRemoveExtensionInstructionAsync(
-            {
-                admin: signer,
-                escrow: escrow as Address,
-                extensionType: Number(extensionType),
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Remove Extension',
-            values: { escrow, extensionType },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        const result = await removeExtension
+            .mutateAsync({ escrow, extensionType: Number(extensionType) })
+            .catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -98,8 +80,8 @@ export function RemoveExtension({
                 options={EXTENSION_OPTIONS}
                 hint="Select which escrow extension to remove"
             />
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={removeExtension.isPending} label={submitLabel} />
+            <TxResult signature={removeExtension.data?.signature} error={formError ?? removeExtension.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/RemoveExtension.tsx
+++ b/apps/web/src/components/instructions/RemoveExtension.tsx
@@ -18,13 +18,27 @@ const EXTENSION_OPTIONS = [
     { label: 'Arbiter (3)', value: '3' },
 ];
 
-export function RemoveExtension() {
+interface RemoveExtensionProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialExtensionType?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function RemoveExtension({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialExtensionType = '0',
+    onSuccess,
+    submitLabel,
+}: RemoveExtensionProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [extensionType, setExtensionType] = useState('0');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [extensionType, setExtensionType] = useState(initialExtensionType);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -55,6 +69,7 @@ export function RemoveExtension() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -65,15 +80,17 @@ export function RemoveExtension() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrow PDA address"
+                    required
+                />
+            )}
             <SelectField
                 label="Extension Type"
                 value={extensionType}
@@ -81,7 +98,7 @@ export function RemoveExtension() {
                 options={EXTENSION_OPTIONS}
                 hint="Select which escrow extension to remove"
             />
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/SetArbiter.tsx
+++ b/apps/web/src/components/instructions/SetArbiter.tsx
@@ -12,12 +12,24 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function SetArbiter() {
+interface SetArbiterProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function SetArbiter({
+    hideKnownFields = false,
+    initialEscrow = '',
+    onSuccess,
+    submitLabel,
+}: SetArbiterProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -53,6 +65,7 @@ export function SetArbiter() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -68,16 +81,18 @@ export function SetArbiter() {
                     Arbiter must co-sign with admin. This form sets your connected wallet as arbiter.
                 </Badge>
             </div>
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
-            <SendButton sending={sending} />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrow PDA address"
+                    required
+                />
+            )}
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/SetArbiter.tsx
+++ b/apps/web/src/components/instructions/SetArbiter.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
 import { Badge } from '@solana/design-system/badge';
-import { findExtensionsPda, getSetArbiterInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -25,19 +21,15 @@ export function SetArbiter({
     onSuccess,
     submitLabel,
 }: SetArbiterProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { setArbiter } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        setArbiter.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(validateAddress(escrow, 'Escrow address'));
         if (validationError) {
@@ -45,28 +37,11 @@ export function SetArbiter({
             return;
         }
 
-        const [, extensionsBump] = await findExtensionsPda(
-            { escrow: escrow as Address },
-            { programAddress: programId as Address },
-        );
-        const ix = await getSetArbiterInstructionAsync(
-            {
-                admin: signer,
-                arbiter: signer,
-                escrow: escrow as Address,
-                extensionsBump,
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Set Arbiter',
-            values: { escrow },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        const result = await setArbiter.mutateAsync({ escrow }).catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -92,8 +67,8 @@ export function SetArbiter({
                     required
                 />
             )}
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={setArbiter.isPending} label={submitLabel} />
+            <TxResult signature={setArbiter.data?.signature} error={formError ?? setArbiter.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/SetHook.tsx
+++ b/apps/web/src/components/instructions/SetHook.tsx
@@ -11,13 +11,27 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function SetHook() {
+interface SetHookProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialHookProgram?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function SetHook({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialHookProgram = '',
+    onSuccess,
+    submitLabel,
+}: SetHookProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [hookProgram, setHookProgram] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [hookProgram, setHookProgram] = useState(initialHookProgram);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -51,6 +65,7 @@ export function SetHook() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -61,15 +76,17 @@ export function SetHook() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrow PDA address"
+                    required
+                />
+            )}
             <FormField
                 label="Hook Program Address"
                 value={hookProgram}
@@ -78,7 +95,7 @@ export function SetHook() {
                 hint="Warning: if this escrow is later set immutable, this hook dependency becomes permanent and hook reverts will block operations."
                 required
             />
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/SetHook.tsx
+++ b/apps/web/src/components/instructions/SetHook.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
-import { getSetHookInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -26,20 +22,16 @@ export function SetHook({
     onSuccess,
     submitLabel,
 }: SetHookProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { setHook } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [hookProgram, setHookProgram] = useState(initialHookProgram);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        setHook.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(
             validateAddress(escrow, 'Escrow address'),
@@ -50,23 +42,11 @@ export function SetHook({
             return;
         }
 
-        const ix = await getSetHookInstructionAsync(
-            {
-                admin: signer,
-                escrow: escrow as Address,
-                hookProgram: hookProgram as Address,
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Set Hook',
-            values: { escrow, hookProgram },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        const result = await setHook.mutateAsync({ escrow, hookProgram }).catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -95,8 +75,8 @@ export function SetHook({
                 hint="Warning: if this escrow is later set immutable, this hook dependency becomes permanent and hook reverts will block operations."
                 required
             />
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={setHook.isPending} label={submitLabel} />
+            <TxResult signature={setHook.data?.signature} error={formError ?? setHook.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/SetImmutable.tsx
+++ b/apps/web/src/components/instructions/SetImmutable.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
 import { Badge } from '@solana/design-system/badge';
-import { getSetImmutableInstruction } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -25,19 +21,15 @@ export function SetImmutable({
     onSuccess,
     submitLabel,
 }: SetImmutableProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { setImmutable } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        setImmutable.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(validateAddress(escrow, 'Escrow address'));
         if (validationError) {
@@ -45,22 +37,11 @@ export function SetImmutable({
             return;
         }
 
-        const ix = getSetImmutableInstruction(
-            {
-                admin: signer,
-                escrow: escrow as Address,
-            },
-            { programAddress: programId as Address },
-        );
+        const result = await setImmutable.mutateAsync({ escrow }).catch(() => null);
+        if (!result) return;
 
-        const txSignature = await send([ix], {
-            action: 'Set Immutable',
-            values: { escrow },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -87,8 +68,8 @@ export function SetImmutable({
                     required
                 />
             )}
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={setImmutable.isPending} label={submitLabel} />
+            <TxResult signature={setImmutable.data?.signature} error={formError ?? setImmutable.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/SetImmutable.tsx
+++ b/apps/web/src/components/instructions/SetImmutable.tsx
@@ -12,12 +12,24 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function SetImmutable() {
+interface SetImmutableProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function SetImmutable({
+    hideKnownFields = false,
+    initialEscrow = '',
+    onSuccess,
+    submitLabel,
+}: SetImmutableProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -47,6 +59,7 @@ export function SetImmutable() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -63,16 +76,18 @@ export function SetImmutable() {
                     becomes permanent, and hook reverts will block escrow operations.
                 </Badge>
             </div>
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrowae7..."
-                required
-            />
-            <SendButton sending={sending} />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrowae7..."
+                    required
+                />
+            )}
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/UnblockTokenExtension.tsx
+++ b/apps/web/src/components/instructions/UnblockTokenExtension.tsx
@@ -21,13 +21,27 @@ const EXTENSION_OPTIONS = [
     { label: 'MetadataPointer (18)', value: '18' },
 ];
 
-export function UnblockTokenExtension() {
+interface UnblockTokenExtensionProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialExtensionType?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function UnblockTokenExtension({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialExtensionType = '5',
+    onSuccess,
+    submitLabel,
+}: UnblockTokenExtensionProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
-    const [blockedExtension, setBlockedExtension] = useState('5');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [blockedExtension, setBlockedExtension] = useState(initialExtensionType);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -58,6 +72,7 @@ export function UnblockTokenExtension() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -68,15 +83,17 @@ export function UnblockTokenExtension() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrow PDA address"
+                    required
+                />
+            )}
             <SelectField
                 label="Extension Type"
                 value={blockedExtension}
@@ -84,7 +101,7 @@ export function UnblockTokenExtension() {
                 options={EXTENSION_OPTIONS}
                 hint="Token-2022 extension type to remove from escrow blocked list"
             />
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/UnblockTokenExtension.tsx
+++ b/apps/web/src/components/instructions/UnblockTokenExtension.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
-import { getUnblockTokenExtensionInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SelectField, SendButton } from './shared';
@@ -36,20 +32,16 @@ export function UnblockTokenExtension({
     onSuccess,
     submitLabel,
 }: UnblockTokenExtensionProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { unblockTokenExtension } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [blockedExtension, setBlockedExtension] = useState(initialExtensionType);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        unblockTokenExtension.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(validateAddress(escrow, 'Escrow address'));
         if (validationError) {
@@ -57,23 +49,13 @@ export function UnblockTokenExtension({
             return;
         }
 
-        const ix = await getUnblockTokenExtensionInstructionAsync(
-            {
-                admin: signer,
-                escrow: escrow as Address,
-                blockedExtension: Number(blockedExtension),
-                payer: signer,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Unblock Token Extension',
-            values: { escrow, extensionType: blockedExtension },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        const result = await unblockTokenExtension
+            .mutateAsync({ escrow, extensionType: Number(blockedExtension) })
+            .catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -101,8 +83,11 @@ export function UnblockTokenExtension({
                 options={EXTENSION_OPTIONS}
                 hint="Token-2022 extension type to remove from escrow blocked list"
             />
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={unblockTokenExtension.isPending} label={submitLabel} />
+            <TxResult
+                signature={unblockTokenExtension.data?.signature}
+                error={formError ?? unblockTokenExtension.error}
+            />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/UpdateAdmin.tsx
+++ b/apps/web/src/components/instructions/UpdateAdmin.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import type { Address } from '@solana/kit';
 import { Badge } from '@solana/design-system/badge';
-import { getUpdateAdminInstruction } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
-import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
@@ -25,19 +21,15 @@ export function UpdateAdmin({
     onSuccess,
     submitLabel,
 }: UpdateAdminProps = {}) {
-    const { createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { updateAdmin } = useEscrowMutations();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
-    const { programId } = useProgramContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        updateAdmin.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(validateAddress(escrow, 'Escrow address'));
         if (validationError) {
@@ -45,22 +37,11 @@ export function UpdateAdmin({
             return;
         }
 
-        const ix = getUpdateAdminInstruction(
-            {
-                admin: signer,
-                newAdmin: signer,
-                escrow: escrow as Address,
-            },
-            { programAddress: programId as Address },
-        );
-        const txSignature = await send([ix], {
-            action: 'Update Admin',
-            values: { escrow },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            onSuccess?.();
-        }
+        const result = await updateAdmin.mutateAsync({ escrow }).catch(() => null);
+        if (!result) return;
+
+        rememberEscrow(escrow);
+        onSuccess?.();
     };
 
     return (
@@ -84,8 +65,8 @@ export function UpdateAdmin({
                     required
                 />
             )}
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={updateAdmin.isPending} label={submitLabel} />
+            <TxResult signature={updateAdmin.data?.signature} error={formError ?? updateAdmin.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/UpdateAdmin.tsx
+++ b/apps/web/src/components/instructions/UpdateAdmin.tsx
@@ -12,12 +12,24 @@ import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
 
-export function UpdateAdmin() {
+interface UpdateAdminProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function UpdateAdmin({
+    hideKnownFields = false,
+    initialEscrow = '',
+    onSuccess,
+    submitLabel,
+}: UpdateAdminProps = {}) {
     const { createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, rememberEscrow } = useSavedValues();
     const { programId } = useProgramContext();
-    const [escrow, setEscrow] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -47,6 +59,7 @@ export function UpdateAdmin() {
         });
         if (txSignature) {
             rememberEscrow(escrow);
+            onSuccess?.();
         }
     };
 
@@ -60,16 +73,18 @@ export function UpdateAdmin() {
             <div>
                 <Badge variant="info">Current and new admin must both sign. This form uses your wallet for both.</Badge>
             </div>
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrowae7..."
-                required
-            />
-            <SendButton sending={sending} />
+            {!hideKnownFields && (
+                <FormField
+                    label="Escrow Address"
+                    value={escrow}
+                    onChange={setEscrow}
+                    autoFillValue={defaultEscrow}
+                    onAutoFill={setEscrow}
+                    placeholder="Escrowae7..."
+                    required
+                />
+            )}
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/Withdraw.tsx
+++ b/apps/web/src/components/instructions/Withdraw.tsx
@@ -45,17 +45,35 @@ function parseExtensions(data: Uint8Array): { arbiter: Address | null; hookProgr
     return { arbiter, hookProgram };
 }
 
-export function Withdraw() {
+interface WithdrawProps {
+    hideKnownFields?: boolean;
+    initialEscrow?: string;
+    initialMint?: string;
+    initialReceipt?: string;
+    initialRentRecipient?: string;
+    onSuccess?: () => void;
+    submitLabel?: string;
+}
+
+export function Withdraw({
+    hideKnownFields = false,
+    initialEscrow = '',
+    initialMint = '',
+    initialReceipt = '',
+    initialRentRecipient = '',
+    onSuccess,
+    submitLabel,
+}: WithdrawProps = {}) {
     const { account, createSigner } = useWallet();
     const { send, sending, signature, error, reset } = useSendTx();
     const { defaultEscrow, defaultMint, defaultReceipt, rememberEscrow, rememberMint, rememberReceipt } =
         useSavedValues();
     const { programId } = useProgramContext();
     const { rpcUrl } = useRpcContext();
-    const [escrow, setEscrow] = useState('');
-    const [mint, setMint] = useState('');
-    const [receipt, setReceipt] = useState('');
-    const [rentRecipient, setRentRecipient] = useState('');
+    const [escrow, setEscrow] = useState(initialEscrow);
+    const [mint, setMint] = useState(initialMint);
+    const [receipt, setReceipt] = useState(initialReceipt);
+    const [rentRecipient, setRentRecipient] = useState(initialRentRecipient);
     const [formError, setFormError] = useState<string | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -124,6 +142,7 @@ export function Withdraw() {
             rememberEscrow(escrow);
             rememberMint(mint);
             rememberReceipt(receipt);
+            onSuccess?.();
         }
     };
 
@@ -134,34 +153,38 @@ export function Withdraw() {
             }}
             style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
         >
-            <FormField
-                label="Escrow Address"
-                value={escrow}
-                onChange={setEscrow}
-                autoFillValue={defaultEscrow}
-                onAutoFill={setEscrow}
-                placeholder="Escrow PDA address"
-                required
-            />
-            <FormField
-                label="Mint Address"
-                value={mint}
-                onChange={setMint}
-                autoFillValue={defaultMint}
-                onAutoFill={setMint}
-                placeholder="SPL token mint address"
-                required
-            />
-            <FormField
-                label="Receipt Address"
-                value={receipt}
-                onChange={setReceipt}
-                autoFillValue={defaultReceipt}
-                onAutoFill={setReceipt}
-                placeholder="Receipt PDA address from deposit"
-                hint="The receipt PDA created during Deposit"
-                required
-            />
+            {!hideKnownFields && (
+                <>
+                    <FormField
+                        label="Escrow Address"
+                        value={escrow}
+                        onChange={setEscrow}
+                        autoFillValue={defaultEscrow}
+                        onAutoFill={setEscrow}
+                        placeholder="Escrow PDA address"
+                        required
+                    />
+                    <FormField
+                        label="Mint Address"
+                        value={mint}
+                        onChange={setMint}
+                        autoFillValue={defaultMint}
+                        onAutoFill={setMint}
+                        placeholder="SPL token mint address"
+                        required
+                    />
+                    <FormField
+                        label="Receipt Address"
+                        value={receipt}
+                        onChange={setReceipt}
+                        autoFillValue={defaultReceipt}
+                        onAutoFill={setReceipt}
+                        placeholder="Receipt PDA address from deposit"
+                        hint="The receipt PDA created during Deposit"
+                        required
+                    />
+                </>
+            )}
             <FormField
                 label="Rent Recipient"
                 value={rentRecipient}
@@ -169,7 +192,7 @@ export function Withdraw() {
                 placeholder={account?.address ?? 'Defaults to connected wallet'}
                 hint="Address that receives rent from the closed receipt account"
             />
-            <SendButton sending={sending} />
+            <SendButton sending={sending} label={submitLabel} />
             <TxResult signature={signature} error={formError ?? error} />
         </form>
     );

--- a/apps/web/src/components/instructions/Withdraw.tsx
+++ b/apps/web/src/components/instructions/Withdraw.tsx
@@ -1,49 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { AccountRole, type Address, fetchEncodedAccount, createSolanaRpc, getAddressDecoder } from '@solana/kit';
-import { findExtensionsPda, getWithdrawInstructionAsync } from '@solana/escrow';
-import { useSendTx } from '@/hooks/useSendTx';
 import { useSavedValues } from '@/contexts/SavedValuesContext';
 import { useWallet } from '@/contexts/WalletContext';
-import { useProgramContext } from '@/contexts/ProgramContext';
-import { useRpcContext } from '@/contexts/RpcContext';
+import { useEscrowMutations } from '@/hooks/use-escrow-mutations';
 import { TxResult } from '@/components/TxResult';
 import { firstValidationError, validateAddress, validateOptionalAddress } from '@/lib/validation';
 import { FormField, SendButton } from './shared';
-
-// TLV layout: [discriminator(1), version(1), bump(1), extensionCount(1), ...entries]
-// Each entry: [type(u16-LE), length(u16-LE), data(length bytes)]
-const HEADER_SIZE = 4;
-const ENTRY_HEADER_SIZE = 4;
-const HOOK_TYPE = 1;
-const ARBITER_TYPE = 3;
-
-function parseExtensions(data: Uint8Array): { arbiter: Address | null; hookProgram: Address | null } {
-    let arbiter: Address | null = null;
-    let hookProgram: Address | null = null;
-
-    const decoder = getAddressDecoder();
-    let offset = HEADER_SIZE;
-
-    while (offset + ENTRY_HEADER_SIZE <= data.length) {
-        const type = data[offset] | (data[offset + 1] << 8);
-        const length = data[offset + 2] | (data[offset + 3] << 8);
-        const start = offset + ENTRY_HEADER_SIZE;
-        const end = start + length;
-        if (end > data.length) break;
-
-        if (type === ARBITER_TYPE && length >= 32) {
-            arbiter = decoder.decode(data.slice(start, start + 32));
-        } else if (type === HOOK_TYPE && length >= 32) {
-            hookProgram = decoder.decode(data.slice(start, start + 32));
-        }
-
-        offset = end;
-    }
-
-    return { arbiter, hookProgram };
-}
 
 interface WithdrawProps {
     hideKnownFields?: boolean;
@@ -64,12 +27,10 @@ export function Withdraw({
     onSuccess,
     submitLabel,
 }: WithdrawProps = {}) {
-    const { account, createSigner } = useWallet();
-    const { send, sending, signature, error, reset } = useSendTx();
+    const { account } = useWallet();
+    const { withdraw } = useEscrowMutations();
     const { defaultEscrow, defaultMint, defaultReceipt, rememberEscrow, rememberMint, rememberReceipt } =
         useSavedValues();
-    const { programId } = useProgramContext();
-    const { rpcUrl } = useRpcContext();
     const [escrow, setEscrow] = useState(initialEscrow);
     const [mint, setMint] = useState(initialMint);
     const [receipt, setReceipt] = useState(initialReceipt);
@@ -78,10 +39,8 @@ export function Withdraw({
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        reset();
+        withdraw.reset();
         setFormError(null);
-        const signer = createSigner();
-        if (!signer) return;
 
         const validationError = firstValidationError(
             validateAddress(escrow, 'Escrow address'),
@@ -94,56 +53,20 @@ export function Withdraw({
             return;
         }
 
-        // Auto-detect arbiter + hook from the extensions PDA and append as remaining accounts.
-        const [extensionsPda] = await findExtensionsPda(
-            { escrow: escrow as Address },
-            { programAddress: programId as Address },
-        );
-        const rpc = createSolanaRpc(rpcUrl);
-        const extensionsAccount = await fetchEncodedAccount(rpc, extensionsPda);
+        const result = await withdraw
+            .mutateAsync({
+                escrow,
+                mint,
+                receipt,
+                rentRecipient,
+            })
+            .catch(() => null);
+        if (!result) return;
 
-        const remainingAccounts: object[] = [];
-        if (extensionsAccount.exists) {
-            const { arbiter, hookProgram } = parseExtensions(new Uint8Array(extensionsAccount.data));
-            // Arbiter must be first and must sign.
-            // If the arbiter is the connected wallet, attach the signer so @solana/kit's
-            // signTransactionMessageWithSigners knows to call it.
-            if (arbiter) {
-                remainingAccounts.push(
-                    arbiter === (signer.address as string)
-                        ? { address: arbiter, role: AccountRole.READONLY_SIGNER, signer }
-                        : { address: arbiter, role: AccountRole.READONLY_SIGNER },
-                );
-            }
-            // Hook program comes after arbiter (the processor slices past it before invoking the hook).
-            if (hookProgram) remainingAccounts.push({ address: hookProgram, role: AccountRole.READONLY });
-        }
-
-        const ix = await getWithdrawInstructionAsync(
-            {
-                withdrawer: signer,
-                escrow: escrow as Address,
-                mint: mint as Address,
-                receipt: receipt as Address,
-                rentRecipient: (rentRecipient || signer.address) as Address,
-            },
-            { programAddress: programId as Address },
-        );
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const finalIx: any =
-            remainingAccounts.length > 0 ? { ...ix, accounts: [...ix.accounts, ...remainingAccounts] } : ix;
-
-        const txSignature = await send([finalIx], {
-            action: 'Withdraw',
-            values: { escrow, mint, receipt, rentRecipient: rentRecipient || account?.address || '' },
-        });
-        if (txSignature) {
-            rememberEscrow(escrow);
-            rememberMint(mint);
-            rememberReceipt(receipt);
-            onSuccess?.();
-        }
+        rememberEscrow(escrow);
+        rememberMint(mint);
+        rememberReceipt(receipt);
+        onSuccess?.();
     };
 
     return (
@@ -192,8 +115,8 @@ export function Withdraw({
                 placeholder={account?.address ?? 'Defaults to connected wallet'}
                 hint="Address that receives rent from the closed receipt account"
             />
-            <SendButton sending={sending} label={submitLabel} />
-            <TxResult signature={signature} error={formError ?? error} />
+            <SendButton sending={withdraw.isPending} label={submitLabel} />
+            <TxResult signature={withdraw.data?.signature} error={formError ?? withdraw.error} />
         </form>
     );
 }

--- a/apps/web/src/components/instructions/shared.tsx
+++ b/apps/web/src/components/instructions/shared.tsx
@@ -79,10 +79,10 @@ export function SelectField({ label, value, onChange, options, hint }: SelectFie
     );
 }
 
-export function SendButton({ sending }: { sending: boolean }) {
+export function SendButton({ label = 'Send Transaction', sending }: { label?: string; sending: boolean }) {
     return (
         <Button type="submit" loading={sending} disabled={sending} style={{ marginTop: 8, alignSelf: 'flex-start' }}>
-            {sending ? 'Sending Transaction' : 'Send Transaction'}
+            {sending ? 'Sending Transaction' : label}
         </Button>
     );
 }

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,109 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+    return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+    return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+    return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+    return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+    return (
+        <DialogPrimitive.Overlay
+            data-slot="dialog-overlay"
+            className={cn(
+                'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-foreground/40',
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function DialogContent({ children, className, ...props }: React.ComponentProps<typeof DialogPrimitive.Content>) {
+    return (
+        <DialogPortal data-slot="dialog-portal">
+            <DialogOverlay />
+            <DialogPrimitive.Content
+                data-slot="dialog-content"
+                className={cn(
+                    'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+                    className,
+                )}
+                {...props}
+            >
+                {children}
+                <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+                    <XIcon />
+                    <span className="sr-only">Close</span>
+                </DialogPrimitive.Close>
+            </DialogPrimitive.Content>
+        </DialogPortal>
+    );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+    return (
+        <div
+            data-slot="dialog-header"
+            className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+            {...props}
+        />
+    );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+    return (
+        <div
+            data-slot="dialog-footer"
+            className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+            {...props}
+        />
+    );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+    return (
+        <DialogPrimitive.Title
+            data-slot="dialog-title"
+            className={cn('text-lg leading-none font-semibold', className)}
+            {...props}
+        />
+    );
+}
+
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+    return (
+        <DialogPrimitive.Description
+            data-slot="dialog-description"
+            className={cn('text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    );
+}
+
+export {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogOverlay,
+    DialogPortal,
+    DialogTitle,
+    DialogTrigger,
+};

--- a/apps/web/src/components/use-transaction-toast.tsx
+++ b/apps/web/src/components/use-transaction-toast.tsx
@@ -1,0 +1,36 @@
+import { toast } from 'sonner';
+
+import { useClusterConfig } from '@/hooks/use-cluster-config';
+import { getClusterFromClusterId, getSolanaExplorerUrl } from '@/lib/explorer';
+import { formatTransactionError } from '@/lib/transactionErrors';
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : formatTransactionError(error);
+}
+
+export function useTransactionToast() {
+    const { id } = useClusterConfig();
+    const cluster = getClusterFromClusterId(id);
+
+    return {
+        onError: (error: unknown) => {
+            toast.error('Transaction failed', {
+                description: errorMessage(error),
+            });
+        },
+        onSuccess: (signature: string) => {
+            toast.success('Transaction confirmed', {
+                description: (
+                    <a
+                        className="font-medium underline underline-offset-4"
+                        href={getSolanaExplorerUrl(signature, cluster)}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        View Transaction
+                    </a>
+                ),
+            });
+        },
+    };
+}

--- a/apps/web/src/hooks/use-escrow-accounts.ts
+++ b/apps/web/src/hooks/use-escrow-accounts.ts
@@ -1,0 +1,110 @@
+import { useWallet } from '@solana/connector/react';
+import { type Address, address } from '@solana/kit';
+import { useQuery } from '@tanstack/react-query';
+
+import { useProgramContext } from '@/contexts/ProgramContext';
+import { useClusterConfig } from '@/hooks/use-cluster-config';
+import { useRpc } from '@/hooks/useRpc';
+import {
+    fetchAdminEscrows,
+    fetchDepositorReceipts,
+    fetchEscrowDashboardData,
+    fetchEscrowExtensions,
+    fetchEscrowReceipts,
+    fetchKnownAllowedMints,
+} from '@/lib/escrow-accounts';
+
+function knownAddressesKey(addresses: readonly string[]): string {
+    return [...new Set(addresses.map(value => value.trim()).filter(Boolean))].sort().join('|');
+}
+
+function knownAddresses(values: readonly string[]): Address[] {
+    return [...new Set(values.map(value => value.trim()).filter(Boolean))].sort().map(value => address(value));
+}
+
+export function useAdminEscrows() {
+    const { account } = useWallet();
+    const cluster = useClusterConfig();
+    const { programId } = useProgramContext();
+    const rpc = useRpc();
+
+    return useQuery({
+        enabled: Boolean(account),
+        queryFn: () => fetchAdminEscrows(rpc, address(account!), address(programId)),
+        queryKey: ['escrow', 'admin-escrows', account, cluster.id, programId],
+    });
+}
+
+export function useDepositorReceipts() {
+    const { account } = useWallet();
+    const cluster = useClusterConfig();
+    const { programId } = useProgramContext();
+    const rpc = useRpc();
+
+    return useQuery({
+        enabled: Boolean(account),
+        queryFn: () => fetchDepositorReceipts(rpc, address(account!), address(programId)),
+        queryKey: ['escrow', 'depositor-receipts', account, cluster.id, programId],
+    });
+}
+
+export function useEscrowReceipts(escrow: string | null | undefined) {
+    const cluster = useClusterConfig();
+    const { programId } = useProgramContext();
+    const rpc = useRpc();
+    const normalizedEscrow = escrow?.trim() ?? '';
+
+    return useQuery({
+        enabled: normalizedEscrow.length > 0,
+        queryFn: () => fetchEscrowReceipts(rpc, address(normalizedEscrow), address(programId)),
+        queryKey: ['escrow', 'escrow-receipts', normalizedEscrow, cluster.id, programId],
+    });
+}
+
+export function useEscrowExtensions(escrow: string | null | undefined) {
+    const cluster = useClusterConfig();
+    const { programId } = useProgramContext();
+    const rpc = useRpc();
+    const normalizedEscrow = escrow?.trim() ?? '';
+
+    return useQuery({
+        enabled: normalizedEscrow.length > 0,
+        queryFn: () => fetchEscrowExtensions(rpc, address(normalizedEscrow), address(programId)),
+        queryKey: ['escrow', 'extensions', normalizedEscrow, cluster.id, programId],
+    });
+}
+
+export function useKnownAllowedMints(escrows: readonly string[], mints: readonly string[]) {
+    const cluster = useClusterConfig();
+    const { programId } = useProgramContext();
+    const rpc = useRpc();
+    const normalizedEscrows = knownAddresses(escrows);
+    const normalizedMints = knownAddresses(mints);
+
+    return useQuery({
+        enabled: normalizedEscrows.length > 0 && normalizedMints.length > 0,
+        queryFn: () => fetchKnownAllowedMints(rpc, normalizedEscrows, normalizedMints, address(programId)),
+        queryKey: [
+            'escrow',
+            'known-allowed-mints',
+            knownAddressesKey(escrows),
+            knownAddressesKey(mints),
+            cluster.id,
+            programId,
+        ],
+    });
+}
+
+export function useEscrowDashboardData(knownMints: readonly string[] = []) {
+    const { account } = useWallet();
+    const cluster = useClusterConfig();
+    const { programId } = useProgramContext();
+    const rpc = useRpc();
+    const normalizedKnownMints = knownAddresses(knownMints);
+
+    return useQuery({
+        enabled: Boolean(account),
+        queryFn: () => fetchEscrowDashboardData(rpc, address(account!), address(programId), normalizedKnownMints),
+        queryKey: ['escrow', 'dashboard', account, knownAddressesKey(knownMints), cluster.id, programId],
+    });
+}

--- a/apps/web/src/hooks/use-escrow-mutations.ts
+++ b/apps/web/src/hooks/use-escrow-mutations.ts
@@ -1,0 +1,573 @@
+import {
+    findEscrowPda,
+    findExtensionsPda,
+    findReceiptPda,
+    getAddTimelockInstructionAsync,
+    getAllowMintInstructionAsync,
+    getBlockMintInstructionAsync,
+    getBlockTokenExtensionInstructionAsync,
+    getCreatesEscrowInstructionAsync,
+    getDepositInstructionAsync,
+    getRemoveExtensionInstructionAsync,
+    getSetArbiterInstructionAsync,
+    getSetHookInstructionAsync,
+    getSetImmutableInstruction,
+    getUnblockTokenExtensionInstructionAsync,
+    getUpdateAdminInstruction,
+    getWithdrawInstructionAsync,
+} from '@solana/escrow';
+import {
+    type AccountMeta,
+    AccountRole,
+    type AccountSignerMeta,
+    type Address,
+    address,
+    fetchEncodedAccount,
+    generateKeyPairSigner,
+    getAddressDecoder,
+    type Instruction,
+    type TransactionSigner,
+} from '@solana/kit';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useWalletTransactionSignAndSend } from '@/components/solana/use-wallet-transaction-sign-and-send';
+import { useTransactionToast } from '@/components/use-transaction-toast';
+import { useProgramContext } from '@/contexts/ProgramContext';
+import type { RecentTransactionValues } from '@/contexts/RecentTransactionsContext';
+import { useRecentTransactions } from '@/contexts/RecentTransactionsContext';
+import { useWallet } from '@/contexts/WalletContext';
+import { formatTransactionError } from '@/lib/transactionErrors';
+import { invalidateWithDelay } from '@/lib/utils';
+
+import { useRpc } from './useRpc';
+
+const HEADER_SIZE = 4;
+const ENTRY_HEADER_SIZE = 4;
+const HOOK_TYPE = 1;
+const ARBITER_TYPE = 3;
+
+interface EscrowMutationResult {
+    readonly signature: string;
+}
+
+interface CreateEscrowMutationResult extends EscrowMutationResult {
+    readonly escrow: string;
+    readonly seed: string;
+}
+
+interface DepositMutationResult extends EscrowMutationResult {
+    readonly amount: bigint;
+    readonly escrow: string;
+    readonly mint: string;
+    readonly receipt: string;
+    readonly receiptSeed: string;
+}
+
+export interface DepositInput {
+    readonly amount: bigint;
+    readonly escrow: string;
+    readonly mint: string;
+}
+
+export interface WithdrawInput {
+    readonly escrow: string;
+    readonly mint: string;
+    readonly receipt: string;
+    readonly rentRecipient?: string;
+}
+
+export interface EscrowMintInput {
+    readonly escrow: string;
+    readonly mint: string;
+}
+
+export interface BlockMintInput extends EscrowMintInput {
+    readonly rentRecipient?: string;
+}
+
+export interface EscrowInput {
+    readonly escrow: string;
+}
+
+export interface AddTimelockInput extends EscrowInput {
+    readonly lockDuration: bigint;
+}
+
+export interface SetHookInput extends EscrowInput {
+    readonly hookProgram: string;
+}
+
+export interface TokenExtensionInput extends EscrowInput {
+    readonly extensionType: number;
+}
+
+function asAddress(value: string): Address {
+    return address(value.trim());
+}
+
+function getProgramAddress(value: string): Address {
+    return address(value.trim());
+}
+
+function createTransactionId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function normalizeValues(values?: RecentTransactionValues): RecentTransactionValues | undefined {
+    if (!values) return undefined;
+    const entries = Object.entries(values as Record<string, string | undefined>)
+        .map(([key, value]) => [key, value?.trim() ?? ''] as const)
+        .filter(([, value]) => value.length > 0);
+    if (entries.length === 0) return undefined;
+    return Object.fromEntries(entries);
+}
+
+function parseExtensions(data: Uint8Array): { arbiter: Address | null; hookProgram: Address | null } {
+    let arbiter: Address | null = null;
+    let hookProgram: Address | null = null;
+    const decoder = getAddressDecoder();
+    let offset = HEADER_SIZE;
+
+    while (offset + ENTRY_HEADER_SIZE <= data.length) {
+        const type = data[offset] | (data[offset + 1] << 8);
+        const length = data[offset + 2] | (data[offset + 3] << 8);
+        const start = offset + ENTRY_HEADER_SIZE;
+        const end = start + length;
+        if (end > data.length) break;
+
+        if (type === ARBITER_TYPE && length >= 32) {
+            arbiter = decoder.decode(data.slice(start, start + 32));
+        } else if (type === HOOK_TYPE && length >= 32) {
+            hookProgram = decoder.decode(data.slice(start, start + 32));
+        }
+
+        offset = end;
+    }
+
+    return { arbiter, hookProgram };
+}
+
+export function useEscrowMutations() {
+    const rpc = useRpc();
+    const signAndSend = useWalletTransactionSignAndSend();
+    const { addRecentTransaction } = useRecentTransactions();
+    const { programId } = useProgramContext();
+    const { createSigner } = useWallet();
+    const queryClient = useQueryClient();
+    const transactionToast = useTransactionToast();
+
+    function requireSigner(): TransactionSigner {
+        const signer = createSigner();
+        if (!signer) throw new Error('Wallet not connected');
+        return signer;
+    }
+
+    async function sendEscrowTransaction(
+        instructions: readonly Instruction[],
+        txSigner: TransactionSigner,
+        action: string,
+        values?: RecentTransactionValues,
+    ): Promise<string> {
+        const normalizedValues = normalizeValues(values);
+        const id = createTransactionId();
+
+        try {
+            const signature = await signAndSend(instructions, txSigner);
+            addRecentTransaction({
+                action,
+                id,
+                signature,
+                status: 'success',
+                timestamp: Date.now(),
+                values: normalizedValues,
+            });
+            return signature;
+        } catch (error) {
+            const message = formatTransactionError(error);
+            addRecentTransaction({
+                action,
+                error: message,
+                id,
+                signature: null,
+                status: 'failed',
+                timestamp: Date.now(),
+                values: normalizedValues,
+            });
+            throw new Error(message, { cause: error });
+        }
+    }
+
+    function onSuccess(result: EscrowMutationResult) {
+        transactionToast.onSuccess(result.signature);
+        invalidateWithDelay(queryClient, [['escrow']]);
+    }
+
+    function onError(error: unknown) {
+        transactionToast.onError(error);
+    }
+
+    const createEscrow = useMutation({
+        mutationFn: async (): Promise<CreateEscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrowSeed = await generateKeyPairSigner();
+            const [escrow] = await findEscrowPda({ escrowSeed: escrowSeed.address }, { programAddress });
+
+            const instruction = await getCreatesEscrowInstructionAsync(
+                {
+                    admin: txSigner,
+                    escrowSeed,
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Create Escrow', { escrow });
+            return { escrow, seed: escrowSeed.address, signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const deposit = useMutation({
+        mutationFn: async (input: DepositInput): Promise<DepositMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const mint = input.mint.trim();
+            const receiptSeed = await generateKeyPairSigner();
+            const [receipt] = await findReceiptPda(
+                {
+                    depositor: txSigner.address,
+                    escrow: asAddress(escrow),
+                    mint: asAddress(mint),
+                    receiptSeed: receiptSeed.address,
+                },
+                { programAddress },
+            );
+
+            const instruction = await getDepositInstructionAsync(
+                {
+                    amount: input.amount,
+                    depositor: txSigner,
+                    escrow: asAddress(escrow),
+                    mint: asAddress(mint),
+                    payer: txSigner,
+                    receiptSeed,
+                },
+                { programAddress },
+            );
+
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Deposit', {
+                amount: String(input.amount),
+                escrow,
+                mint,
+                receipt,
+            });
+            return { amount: input.amount, escrow, mint, receipt, receiptSeed: receiptSeed.address, signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const withdraw = useMutation({
+        mutationFn: async (input: WithdrawInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const mint = input.mint.trim();
+            const receipt = input.receipt.trim();
+            const rentRecipient = input.rentRecipient?.trim() || txSigner.address;
+            const [extensionsPda] = await findExtensionsPda({ escrow: asAddress(escrow) }, { programAddress });
+            const extensionsAccount = await fetchEncodedAccount(rpc, extensionsPda);
+            const remainingAccounts: (AccountMeta | AccountSignerMeta)[] = [];
+
+            if (extensionsAccount.exists) {
+                const { arbiter, hookProgram } = parseExtensions(new Uint8Array(extensionsAccount.data));
+                if (arbiter) {
+                    remainingAccounts.push(
+                        arbiter === txSigner.address
+                            ? { address: arbiter, role: AccountRole.READONLY_SIGNER, signer: txSigner }
+                            : { address: arbiter, role: AccountRole.READONLY_SIGNER },
+                    );
+                }
+                if (hookProgram) remainingAccounts.push({ address: hookProgram, role: AccountRole.READONLY });
+            }
+
+            const instruction = await getWithdrawInstructionAsync(
+                {
+                    escrow: asAddress(escrow),
+                    mint: asAddress(mint),
+                    receipt: asAddress(receipt),
+                    rentRecipient: asAddress(rentRecipient),
+                    withdrawer: txSigner,
+                },
+                { programAddress },
+            );
+            const finalInstruction: Instruction =
+                remainingAccounts.length > 0
+                    ? { ...instruction, accounts: [...instruction.accounts, ...remainingAccounts] }
+                    : instruction;
+
+            const signature = await sendEscrowTransaction([finalInstruction], txSigner, 'Withdraw', {
+                escrow,
+                mint,
+                receipt,
+                rentRecipient,
+            });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const allowMint = useMutation({
+        mutationFn: async (input: EscrowMintInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const mint = input.mint.trim();
+            const instruction = await getAllowMintInstructionAsync(
+                {
+                    admin: txSigner,
+                    escrow: asAddress(escrow),
+                    mint: asAddress(mint),
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Allow Mint', { escrow, mint });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const blockMint = useMutation({
+        mutationFn: async (input: BlockMintInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const mint = input.mint.trim();
+            const rentRecipient = input.rentRecipient?.trim() || txSigner.address;
+            const instruction = await getBlockMintInstructionAsync(
+                {
+                    admin: txSigner,
+                    escrow: asAddress(escrow),
+                    mint: asAddress(mint),
+                    rentRecipient: asAddress(rentRecipient),
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Block Mint', {
+                escrow,
+                mint,
+                rentRecipient,
+            });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const updateAdmin = useMutation({
+        mutationFn: async (input: EscrowInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const instruction = getUpdateAdminInstruction(
+                {
+                    admin: txSigner,
+                    escrow: asAddress(escrow),
+                    newAdmin: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Update Admin', { escrow });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const setImmutable = useMutation({
+        mutationFn: async (input: EscrowInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const instruction = getSetImmutableInstruction(
+                {
+                    admin: txSigner,
+                    escrow: asAddress(escrow),
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Set Immutable', { escrow });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const addTimelock = useMutation({
+        mutationFn: async (input: AddTimelockInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const instruction = await getAddTimelockInstructionAsync(
+                {
+                    admin: txSigner,
+                    escrow: asAddress(escrow),
+                    lockDuration: input.lockDuration,
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Add Timelock', {
+                escrow,
+                lockDuration: String(input.lockDuration),
+            });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const setHook = useMutation({
+        mutationFn: async (input: SetHookInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const hookProgram = input.hookProgram.trim();
+            const instruction = await getSetHookInstructionAsync(
+                {
+                    admin: txSigner,
+                    escrow: asAddress(escrow),
+                    hookProgram: asAddress(hookProgram),
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Set Hook', {
+                escrow,
+                hookProgram,
+            });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const setArbiter = useMutation({
+        mutationFn: async (input: EscrowInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const [, extensionsBump] = await findExtensionsPda({ escrow: asAddress(escrow) }, { programAddress });
+            const instruction = await getSetArbiterInstructionAsync(
+                {
+                    admin: txSigner,
+                    arbiter: txSigner,
+                    escrow: asAddress(escrow),
+                    extensionsBump,
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Set Arbiter', { escrow });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const blockTokenExtension = useMutation({
+        mutationFn: async (input: TokenExtensionInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const [, extensionsBump] = await findExtensionsPda({ escrow: asAddress(escrow) }, { programAddress });
+            const instruction = await getBlockTokenExtensionInstructionAsync(
+                {
+                    admin: txSigner,
+                    blockedExtension: input.extensionType,
+                    escrow: asAddress(escrow),
+                    extensionsBump,
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Block Token Extension', {
+                escrow,
+                extensionType: String(input.extensionType),
+            });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const unblockTokenExtension = useMutation({
+        mutationFn: async (input: TokenExtensionInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const instruction = await getUnblockTokenExtensionInstructionAsync(
+                {
+                    admin: txSigner,
+                    blockedExtension: input.extensionType,
+                    escrow: asAddress(escrow),
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Unblock Token Extension', {
+                escrow,
+                extensionType: String(input.extensionType),
+            });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    const removeExtension = useMutation({
+        mutationFn: async (input: TokenExtensionInput): Promise<EscrowMutationResult> => {
+            const txSigner = requireSigner();
+            const programAddress = getProgramAddress(programId);
+            const escrow = input.escrow.trim();
+            const instruction = await getRemoveExtensionInstructionAsync(
+                {
+                    admin: txSigner,
+                    escrow: asAddress(escrow),
+                    extensionType: input.extensionType,
+                    payer: txSigner,
+                },
+                { programAddress },
+            );
+            const signature = await sendEscrowTransaction([instruction], txSigner, 'Remove Extension', {
+                escrow,
+                extensionType: String(input.extensionType),
+            });
+            return { signature };
+        },
+        onError,
+        onSuccess,
+    });
+
+    return {
+        addTimelock,
+        allowMint,
+        blockMint,
+        blockTokenExtension,
+        createEscrow,
+        deposit,
+        removeExtension,
+        setArbiter,
+        setHook,
+        setImmutable,
+        unblockTokenExtension,
+        updateAdmin,
+        withdraw,
+    };
+}

--- a/apps/web/src/lib/escrow-accounts.ts
+++ b/apps/web/src/lib/escrow-accounts.ts
@@ -1,0 +1,373 @@
+import {
+    decodeEscrow,
+    decodeReceipt,
+    fetchMaybeAllowedMintFromSeeds,
+    findExtensionsPda,
+    type Escrow,
+    type Receipt,
+} from '@solana/escrow';
+import {
+    fetchEncodedAccount,
+    getAddressDecoder,
+    getBase64Encoder,
+    type Account,
+    type Address,
+    type Base58EncodedBytes,
+    type Base64EncodedBytes,
+    type EncodedAccount,
+    type Lamports,
+} from '@solana/kit';
+
+import {
+    allowedMintAccountToRecord,
+    escrowAccountToRecord,
+    receiptAccountToRecord,
+    type AllowedMintRecord,
+    type EscrowDashboardData,
+    type EscrowExtensionsRecord,
+    type EscrowRecord,
+    type EscrowRpc,
+    type ParsedEscrowExtension,
+    type ReceiptRecord,
+} from '@/lib/escrow-model';
+
+const DISCRIMINATOR_OFFSET = 0n;
+const ESCROW_ADMIN_OFFSET = 35n;
+const RECEIPT_ESCROW_OFFSET = 10n;
+const RECEIPT_DEPOSITOR_OFFSET = 42n;
+
+const ESCROW_SIZE = 68n;
+const RECEIPT_SIZE = 154n;
+
+const ESCROW_DISCRIMINATOR = 'AQ==' as Base64EncodedBytes;
+const RECEIPT_DISCRIMINATOR = 'Aw==' as Base64EncodedBytes;
+
+const EXTENSIONS_HEADER_SIZE = 4;
+const TLV_HEADER_SIZE = 4;
+
+const EXTENSION_TYPE_TIMELOCK = 0;
+const EXTENSION_TYPE_HOOK = 1;
+const EXTENSION_TYPE_BLOCKED_TOKEN_EXTENSIONS = 2;
+const EXTENSION_TYPE_ARBITER = 3;
+
+const base64Encoder = getBase64Encoder();
+const addressDecoder = getAddressDecoder();
+
+interface Base64ProgramAccount {
+    account: {
+        data: readonly [Base64EncodedBytes, 'base64'];
+        executable: boolean;
+        lamports: Lamports;
+        owner: Address;
+        space: bigint;
+    };
+    pubkey: Address;
+}
+
+function addressBytes(address: Address): Base58EncodedBytes {
+    return address as unknown as Base58EncodedBytes;
+}
+
+function toEncodedAccount(account: Base64ProgramAccount): EncodedAccount {
+    const [base64Data] = account.account.data;
+    return {
+        address: account.pubkey,
+        data: base64Encoder.encode(base64Data),
+        executable: account.account.executable,
+        lamports: account.account.lamports,
+        programAddress: account.account.owner,
+        space: account.account.space,
+    };
+}
+
+function uniqueAddresses(addresses: readonly Address[]): Address[] {
+    return [...new Set(addresses)].sort((a, b) => a.localeCompare(b));
+}
+
+function readU64LE(data: Uint8Array): bigint {
+    let value = 0n;
+    for (let index = 0; index < Math.min(data.length, 8); index += 1) {
+        value |= BigInt(data[index]) << (BigInt(index) * 8n);
+    }
+    return value;
+}
+
+function readU16LE(data: Uint8Array, offset: number): number {
+    return data[offset] | (data[offset + 1] << 8);
+}
+
+function parseBlockedTokenExtensions(data: Uint8Array): readonly number[] {
+    if (data.length === 0) return [];
+    const count = data[0];
+    const extensions: number[] = [];
+    for (let index = 0; index < count; index += 1) {
+        const offset = 1 + index * 2;
+        if (offset + 2 > data.length) break;
+        extensions.push(readU16LE(data, offset));
+    }
+    return extensions;
+}
+
+function parseExtension(rawType: number, data: Uint8Array): ParsedEscrowExtension {
+    if (rawType === EXTENSION_TYPE_TIMELOCK) {
+        const lockDuration = readU64LE(data);
+        return {
+            enabled: lockDuration !== 0n,
+            kind: 'timelock',
+            lockDuration,
+            rawType,
+        };
+    }
+
+    if (rawType === EXTENSION_TYPE_HOOK && data.length >= 32) {
+        return {
+            hookProgram: addressDecoder.decode(data.slice(0, 32)),
+            kind: 'hook',
+            rawType,
+        };
+    }
+
+    if (rawType === EXTENSION_TYPE_BLOCKED_TOKEN_EXTENSIONS) {
+        return {
+            blockedExtensions: parseBlockedTokenExtensions(data),
+            kind: 'blocked-token-extensions',
+            rawType,
+        };
+    }
+
+    if (rawType === EXTENSION_TYPE_ARBITER && data.length >= 32) {
+        return {
+            arbiter: addressDecoder.decode(data.slice(0, 32)),
+            kind: 'arbiter',
+            rawType,
+        };
+    }
+
+    return {
+        kind: 'unknown',
+        length: data.length,
+        rawType,
+    };
+}
+
+function parseExtensionsAccount(escrow: Address, address: Address, data: Uint8Array): EscrowExtensionsRecord {
+    const bump = data[2] ?? 0;
+    const extensionCount = data[3] ?? 0;
+    const extensions: ParsedEscrowExtension[] = [];
+    let offset = EXTENSIONS_HEADER_SIZE;
+
+    while (offset + TLV_HEADER_SIZE <= data.length) {
+        const rawType = readU16LE(data, offset);
+        const length = readU16LE(data, offset + 2);
+        const start = offset + TLV_HEADER_SIZE;
+        const end = start + length;
+        if (end > data.length) break;
+
+        extensions.push(parseExtension(rawType, data.slice(start, end)));
+        offset = end;
+    }
+
+    const timelock = extensions.find(extension => extension.kind === 'timelock');
+    const hook = extensions.find(extension => extension.kind === 'hook');
+    const arbiter = extensions.find(extension => extension.kind === 'arbiter');
+    const blockedTokenExtensions = extensions.find(extension => extension.kind === 'blocked-token-extensions');
+
+    return {
+        address,
+        arbiter: arbiter?.kind === 'arbiter' ? arbiter.arbiter : null,
+        blockedTokenExtensions:
+            blockedTokenExtensions?.kind === 'blocked-token-extensions' ? blockedTokenExtensions.blockedExtensions : [],
+        bump,
+        escrow,
+        extensionCount,
+        extensions,
+        hookProgram: hook?.kind === 'hook' ? hook.hookProgram : null,
+        lockDuration: timelock?.kind === 'timelock' ? timelock.lockDuration : null,
+    };
+}
+
+function sortEscrows(records: readonly EscrowRecord[]): EscrowRecord[] {
+    return [...records].sort((a, b) => a.address.localeCompare(b.address));
+}
+
+function sortReceipts(records: readonly ReceiptRecord[]): ReceiptRecord[] {
+    return [...records].sort((a, b) => {
+        if (a.depositedAt === b.depositedAt) return a.address.localeCompare(b.address);
+        return a.depositedAt > b.depositedAt ? -1 : 1;
+    });
+}
+
+function sortAllowedMints(records: readonly AllowedMintRecord[]): AllowedMintRecord[] {
+    return [...records].sort((a, b) => a.escrow.localeCompare(b.escrow) || a.mint.localeCompare(b.mint));
+}
+
+async function fetchEscrowAccountsByFilter(
+    rpc: EscrowRpc,
+    programAddress: Address,
+    filter: { bytes: Base58EncodedBytes; offset: bigint },
+): Promise<Account<Escrow>[]> {
+    const accounts = await rpc
+        .getProgramAccounts(programAddress, {
+            encoding: 'base64',
+            filters: [
+                { dataSize: ESCROW_SIZE },
+                {
+                    memcmp: {
+                        bytes: ESCROW_DISCRIMINATOR,
+                        encoding: 'base64',
+                        offset: DISCRIMINATOR_OFFSET,
+                    },
+                },
+                {
+                    memcmp: {
+                        bytes: filter.bytes,
+                        encoding: 'base58',
+                        offset: filter.offset,
+                    },
+                },
+            ],
+        })
+        .send();
+
+    return accounts.map(account => decodeEscrow(toEncodedAccount(account)));
+}
+
+async function fetchReceiptAccountsByFilter(
+    rpc: EscrowRpc,
+    programAddress: Address,
+    filter: { bytes: Base58EncodedBytes; offset: bigint },
+): Promise<Account<Receipt>[]> {
+    const accounts = await rpc
+        .getProgramAccounts(programAddress, {
+            encoding: 'base64',
+            filters: [
+                { dataSize: RECEIPT_SIZE },
+                {
+                    memcmp: {
+                        bytes: RECEIPT_DISCRIMINATOR,
+                        encoding: 'base64',
+                        offset: DISCRIMINATOR_OFFSET,
+                    },
+                },
+                {
+                    memcmp: {
+                        bytes: filter.bytes,
+                        encoding: 'base58',
+                        offset: filter.offset,
+                    },
+                },
+            ],
+        })
+        .send();
+
+    return accounts.map(account => decodeReceipt(toEncodedAccount(account)));
+}
+
+export async function fetchAdminEscrows(
+    rpc: EscrowRpc,
+    admin: Address,
+    programAddress: Address,
+): Promise<EscrowRecord[]> {
+    const accounts = await fetchEscrowAccountsByFilter(rpc, programAddress, {
+        bytes: addressBytes(admin),
+        offset: ESCROW_ADMIN_OFFSET,
+    });
+    return sortEscrows(accounts.map(escrowAccountToRecord));
+}
+
+export async function fetchDepositorReceipts(
+    rpc: EscrowRpc,
+    depositor: Address,
+    programAddress: Address,
+): Promise<ReceiptRecord[]> {
+    const accounts = await fetchReceiptAccountsByFilter(rpc, programAddress, {
+        bytes: addressBytes(depositor),
+        offset: RECEIPT_DEPOSITOR_OFFSET,
+    });
+    return sortReceipts(accounts.map(receiptAccountToRecord));
+}
+
+export async function fetchEscrowReceipts(
+    rpc: EscrowRpc,
+    escrow: Address,
+    programAddress: Address,
+): Promise<ReceiptRecord[]> {
+    const accounts = await fetchReceiptAccountsByFilter(rpc, programAddress, {
+        bytes: addressBytes(escrow),
+        offset: RECEIPT_ESCROW_OFFSET,
+    });
+    return sortReceipts(accounts.map(receiptAccountToRecord));
+}
+
+export async function fetchEscrowExtensions(
+    rpc: EscrowRpc,
+    escrow: Address,
+    programAddress: Address,
+): Promise<EscrowExtensionsRecord | null> {
+    const [extensionsAddress] = await findExtensionsPda({ escrow }, { programAddress });
+    const account = await fetchEncodedAccount(rpc, extensionsAddress);
+    if (!account.exists) return null;
+    return parseExtensionsAccount(escrow, account.address, new Uint8Array(account.data));
+}
+
+export async function fetchKnownAllowedMints(
+    rpc: EscrowRpc,
+    escrows: readonly Address[],
+    mints: readonly Address[],
+    programAddress: Address,
+): Promise<AllowedMintRecord[]> {
+    const pairs = uniqueAddresses(escrows).flatMap(escrow =>
+        uniqueAddresses(mints).map(mint => ({
+            escrow,
+            mint,
+        })),
+    );
+    if (pairs.length === 0) return [];
+
+    const accounts = await Promise.all(
+        pairs.map(async pair => {
+            const account = await fetchMaybeAllowedMintFromSeeds(rpc, pair, { programAddress });
+            return account.exists ? allowedMintAccountToRecord(account, pair.escrow, pair.mint) : null;
+        }),
+    );
+
+    return sortAllowedMints(accounts.filter((account): account is AllowedMintRecord => account !== null));
+}
+
+export async function fetchEscrowDashboardData(
+    rpc: EscrowRpc,
+    wallet: Address,
+    programAddress: Address,
+    knownMints: readonly Address[] = [],
+): Promise<EscrowDashboardData> {
+    const [adminEscrows, depositorReceipts] = await Promise.all([
+        fetchAdminEscrows(rpc, wallet, programAddress),
+        fetchDepositorReceipts(rpc, wallet, programAddress),
+    ]);
+
+    const escrowAddresses = uniqueAddresses([
+        ...adminEscrows.map(escrow => escrow.address),
+        ...depositorReceipts.map(receipt => receipt.escrow),
+    ]);
+    const receiptMints = uniqueAddresses(depositorReceipts.map(receipt => receipt.mint));
+    const mints = uniqueAddresses([...knownMints, ...receiptMints]);
+
+    const [extensionRecords, escrowReceiptGroups, allowedMints] = await Promise.all([
+        Promise.all(escrowAddresses.map(escrow => fetchEscrowExtensions(rpc, escrow, programAddress))),
+        Promise.all(escrowAddresses.map(escrow => fetchEscrowReceipts(rpc, escrow, programAddress))),
+        fetchKnownAllowedMints(rpc, escrowAddresses, mints, programAddress),
+    ]);
+
+    const extensions = new Map<Address, EscrowExtensionsRecord>();
+    for (const record of extensionRecords) {
+        if (record) extensions.set(record.escrow, record);
+    }
+
+    return {
+        adminEscrows,
+        allowedMints,
+        depositorReceipts,
+        escrowReceipts: sortReceipts(escrowReceiptGroups.flat()),
+        extensions,
+    };
+}

--- a/apps/web/src/lib/escrow-model.ts
+++ b/apps/web/src/lib/escrow-model.ts
@@ -1,0 +1,158 @@
+import type { Account, Address, Rpc, SolanaRpcApi } from '@solana/kit';
+import type { AllowedMint, Escrow, Receipt } from '@solana/escrow';
+
+export type EscrowRpc = Rpc<SolanaRpcApi>;
+
+export type EscrowExtensionKind = 'arbiter' | 'blocked-token-extensions' | 'hook' | 'timelock' | 'unknown';
+
+export interface EscrowRecord {
+    readonly address: Address;
+    readonly admin: Address;
+    readonly bump: number;
+    readonly escrowSeed: Address;
+    readonly isImmutable: boolean;
+    readonly version: number;
+}
+
+export interface ReceiptRecord {
+    readonly address: Address;
+    readonly amount: bigint;
+    readonly bump: number;
+    readonly depositedAt: bigint;
+    readonly depositor: Address;
+    readonly escrow: Address;
+    readonly mint: Address;
+    readonly receiptSeed: Address;
+    readonly version: number;
+}
+
+export interface AllowedMintRecord {
+    readonly address: Address;
+    readonly bump: number;
+    readonly escrow: Address;
+    readonly mint: Address;
+    readonly version: number;
+}
+
+export interface EscrowExtensionRecord {
+    readonly kind: EscrowExtensionKind;
+    readonly rawType: number;
+}
+
+export interface TimelockExtensionRecord extends EscrowExtensionRecord {
+    readonly enabled: boolean;
+    readonly kind: 'timelock';
+    readonly lockDuration: bigint;
+}
+
+export interface HookExtensionRecord extends EscrowExtensionRecord {
+    readonly hookProgram: Address;
+    readonly kind: 'hook';
+}
+
+export interface ArbiterExtensionRecord extends EscrowExtensionRecord {
+    readonly arbiter: Address;
+    readonly kind: 'arbiter';
+}
+
+export interface BlockedTokenExtensionsRecord extends EscrowExtensionRecord {
+    readonly blockedExtensions: readonly number[];
+    readonly kind: 'blocked-token-extensions';
+}
+
+export interface UnknownExtensionRecord extends EscrowExtensionRecord {
+    readonly kind: 'unknown';
+    readonly length: number;
+}
+
+export type ParsedEscrowExtension =
+    | ArbiterExtensionRecord
+    | BlockedTokenExtensionsRecord
+    | HookExtensionRecord
+    | TimelockExtensionRecord
+    | UnknownExtensionRecord;
+
+export interface EscrowExtensionsRecord {
+    readonly address: Address;
+    readonly arbiter: Address | null;
+    readonly blockedTokenExtensions: readonly number[];
+    readonly bump: number;
+    readonly escrow: Address;
+    readonly extensionCount: number;
+    readonly extensions: readonly ParsedEscrowExtension[];
+    readonly hookProgram: Address | null;
+    readonly lockDuration: bigint | null;
+}
+
+export interface EscrowDashboardData {
+    readonly adminEscrows: readonly EscrowRecord[];
+    readonly allowedMints: readonly AllowedMintRecord[];
+    readonly depositorReceipts: readonly ReceiptRecord[];
+    readonly escrowReceipts: readonly ReceiptRecord[];
+    readonly extensions: ReadonlyMap<Address, EscrowExtensionsRecord>;
+}
+
+export function escrowAccountToRecord(account: Account<Escrow>): EscrowRecord {
+    return {
+        address: account.address,
+        admin: account.data.admin,
+        bump: account.data.bump,
+        escrowSeed: account.data.escrowSeed,
+        isImmutable: account.data.isImmutable,
+        version: account.data.version,
+    };
+}
+
+export function receiptAccountToRecord(account: Account<Receipt>): ReceiptRecord {
+    return {
+        address: account.address,
+        amount: account.data.amount,
+        bump: account.data.bump,
+        depositedAt: account.data.depositedAt,
+        depositor: account.data.depositor,
+        escrow: account.data.escrow,
+        mint: account.data.mint,
+        receiptSeed: account.data.receiptSeed,
+        version: account.data.version,
+    };
+}
+
+export function allowedMintAccountToRecord(
+    account: Account<AllowedMint>,
+    escrow: Address,
+    mint: Address,
+): AllowedMintRecord {
+    return {
+        address: account.address,
+        bump: account.data.bump,
+        escrow,
+        mint,
+        version: account.data.version,
+    };
+}
+
+export function formatTokenAmount(value: bigint): string {
+    return new Intl.NumberFormat('en-US').format(value);
+}
+
+export function formatAddress(value: string, size = 4): string {
+    if (value.length <= size * 2 + 2) return value;
+    return `${value.slice(0, size)}..${value.slice(-size)}`;
+}
+
+export function receiptUnlockTimestamp(
+    receipt: ReceiptRecord,
+    extensions: EscrowExtensionsRecord | null,
+): bigint | null {
+    if (!extensions?.lockDuration || extensions.lockDuration === 0n) return null;
+    return receipt.depositedAt + extensions.lockDuration;
+}
+
+export function isReceiptWithdrawable(
+    receipt: ReceiptRecord,
+    extensions: EscrowExtensionsRecord | null,
+    now = BigInt(Math.floor(Date.now() / 1000)),
+): boolean {
+    const unlockTimestamp = receiptUnlockTimestamp(receipt, extensions);
+    return unlockTimestamp === null || now >= unlockTimestamp;
+}

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,17 +1,113 @@
 import { Link } from 'react-router';
+import type { ComponentType } from 'react';
+import { Badge } from '@solana/design-system/badge';
+import { ArrowRight, Coins, FileText, LockKeyhole, ShieldCheck, WalletCards } from 'lucide-react';
 
 import { ProgramBadge } from '@/components/ProgramBadge';
 import { QuickDefaults } from '@/components/QuickDefaults';
 import { RecentTransactions } from '@/components/RecentTransactions';
 import { NAV_ITEMS } from '@/components/nav-items';
+import { WalletButton } from '@/components/solana/solana-provider';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useWallet } from '@/contexts/WalletContext';
+import { useSavedValues } from '@/contexts/SavedValuesContext';
+import { useEscrowDashboardData } from '@/hooks/use-escrow-accounts';
+import { formatTokenAmount, isReceiptWithdrawable } from '@/lib/escrow-model';
+
+interface SummaryLinkCardProps {
+    icon: ComponentType<{ className?: string }>;
+    rows: Array<{ label: string; value: string }>;
+    title: string;
+    to: string;
+}
+
+function SummaryLinkCard({ icon: Icon, rows, title, to }: SummaryLinkCardProps) {
+    return (
+        <Link
+            to={to}
+            className="group relative flex flex-col overflow-hidden rounded-lg border-0 border-all-dashed-medium bg-card transition-colors hover:bg-sand-100"
+        >
+            <div className="flex-grow p-5">
+                <div className="mb-6 flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                        <Icon className="h-5 w-5 text-sand-1100" />
+                        <h2 className="text-[17px] font-semibold text-foreground">{title}</h2>
+                    </div>
+                    <ArrowRight className="h-4 w-4 text-sand-1000 transition-transform group-hover:translate-x-0.5" />
+                </div>
+                <div className="space-y-4">
+                    {rows.map((row, index) => (
+                        <div key={row.label} className="space-y-4">
+                            {index > 0 && <div className="h-px w-full bg-sand-100" />}
+                            <div className="flex items-center justify-between gap-3 text-sm">
+                                <span className="text-sand-1100">{row.label}</span>
+                                <span className="truncate text-base font-bold tabular-nums text-foreground">
+                                    {row.value}
+                                </span>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </Link>
+    );
+}
 
 export function Dashboard() {
+    const { connected } = useWallet();
+    const { mints } = useSavedValues();
+    const dashboard = useEscrowDashboardData(mints);
+
+    const data = dashboard.data;
+    const adminEscrows = data?.adminEscrows ?? [];
+    const depositorReceipts = data?.depositorReceipts ?? [];
+    const escrowReceipts = data?.escrowReceipts ?? [];
+    const allowedMints = data?.allowedMints ?? [];
+    const extensionRecords = data ? [...data.extensions.values()] : [];
+    const configuredEscrows = extensionRecords.filter(record => record.extensionCount > 0).length;
+    const withdrawableReceipts = depositorReceipts.filter(receipt =>
+        isReceiptWithdrawable(receipt, data?.extensions.get(receipt.escrow) ?? null),
+    ).length;
+    const totalDeposited = depositorReceipts.reduce((sum, receipt) => sum + receipt.amount, 0n);
+    const extensionCount = extensionRecords.reduce((sum, record) => sum + record.extensionCount, 0);
+    const loadingValue = dashboard.isLoading || dashboard.isFetching ? 'Loading' : '0';
+    const dataError = dashboard.error instanceof Error ? dashboard.error.message : null;
+    const nextAction =
+        withdrawableReceipts > 0
+            ? {
+                  description: `${withdrawableReceipts} receipt${withdrawableReceipts === 1 ? '' : 's'} can be withdrawn.`,
+                  label: 'Withdraw Tokens',
+                  secondaryHref: '/manage',
+                  secondaryLabel: 'Manage Escrows',
+                  to: '/operate',
+              }
+            : adminEscrows.length > 0
+              ? {
+                    description: `${adminEscrows.length} escrow${adminEscrows.length === 1 ? '' : 's'} managed by this wallet.`,
+                    label: 'Manage Escrows',
+                    secondaryHref: '/operate',
+                    secondaryLabel: 'Deposit Tokens',
+                    to: '/manage',
+                }
+              : {
+                    description: 'Create an escrow to start configuring deposits and token rules.',
+                    label: 'Create Escrow',
+                    secondaryHref: '/operate',
+                    secondaryLabel: 'Deposit Tokens',
+                    to: '/create',
+                };
+
     return (
         <div className="space-y-8">
             <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
                 <div className="space-y-4">
                     <div className="flex flex-wrap items-center gap-2">
                         <ProgramBadge />
+                        {connected && (
+                            <Badge variant={dashboard.isFetching ? 'info' : 'success'}>
+                                {dashboard.isFetching ? 'Syncing' : 'Live'}
+                            </Badge>
+                        )}
                     </div>
                     <h1 className="text-3xl font-semibold tracking-tight text-foreground">Escrow Program</h1>
                 </div>
@@ -31,6 +127,107 @@ export function Dashboard() {
                     </div>
                 </div>
             </section>
+            {!connected ? (
+                <Card className="border-0 border-all-dashed-medium bg-card">
+                    <CardContent className="flex flex-col items-center justify-center gap-4 py-14 text-center">
+                        <WalletCards className="h-8 w-8 text-sand-1000" />
+                        <div className="space-y-1">
+                            <h2 className="text-lg font-semibold text-foreground">Connect wallet</h2>
+                            <p className="text-sm text-muted-foreground">Escrow data loads from your wallet.</p>
+                        </div>
+                        <WalletButton />
+                    </CardContent>
+                </Card>
+            ) : (
+                <>
+                    {dataError && (
+                        <Card className="border-0 border-all-dashed-medium bg-card">
+                            <CardContent className="py-5">
+                                <p className="text-sm text-destructive">{dataError}</p>
+                            </CardContent>
+                        </Card>
+                    )}
+                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                        <SummaryLinkCard
+                            icon={ShieldCheck}
+                            title="Managed Escrows"
+                            to="/manage"
+                            rows={[
+                                { label: 'Total', value: data ? adminEscrows.length.toString() : loadingValue },
+                                {
+                                    label: 'Configured',
+                                    value: data ? configuredEscrows.toString() : loadingValue,
+                                },
+                            ]}
+                        />
+                        <SummaryLinkCard
+                            icon={FileText}
+                            title="Deposit Receipts"
+                            to="/operate"
+                            rows={[
+                                { label: 'Receipts', value: data ? depositorReceipts.length.toString() : loadingValue },
+                                {
+                                    label: 'Withdrawable',
+                                    value: data ? withdrawableReceipts.toString() : loadingValue,
+                                },
+                            ]}
+                        />
+                        <SummaryLinkCard
+                            icon={Coins}
+                            title="Known Mints"
+                            to="/create"
+                            rows={[
+                                { label: 'Allowed', value: data ? allowedMints.length.toString() : loadingValue },
+                                { label: 'Saved', value: mints.length.toString() },
+                            ]}
+                        />
+                        <SummaryLinkCard
+                            icon={LockKeyhole}
+                            title="Escrow Activity"
+                            to="/manage"
+                            rows={[
+                                { label: 'Deposits', value: data ? escrowReceipts.length.toString() : loadingValue },
+                                { label: 'Extensions', value: data ? extensionCount.toString() : loadingValue },
+                            ]}
+                        />
+                    </div>
+                    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+                        <Card className="border-0 border-all-dashed-medium bg-card">
+                            <CardHeader>
+                                <CardTitle>Total Deposited By Wallet</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <p className="text-4xl font-semibold tabular-nums text-foreground">
+                                    {data ? formatTokenAmount(totalDeposited) : 'Loading'}
+                                </p>
+                            </CardContent>
+                        </Card>
+                        <Card className="border-0 border-all-dashed-medium bg-card">
+                            <CardHeader>
+                                <CardTitle>Next Action</CardTitle>
+                            </CardHeader>
+                            <CardContent className="flex flex-col gap-3">
+                                <p className="text-sm text-muted-foreground">
+                                    {dashboard.isLoading ? 'Escrow data is syncing.' : nextAction.description}
+                                </p>
+                                <Link
+                                    to={nextAction.to}
+                                    className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                                >
+                                    {nextAction.label}
+                                    <ArrowRight className="h-4 w-4" />
+                                </Link>
+                                <Link
+                                    to={nextAction.secondaryHref}
+                                    className="inline-flex items-center justify-center rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80"
+                                >
+                                    {nextAction.secondaryLabel}
+                                </Link>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </>
+            )}
             <QuickDefaults />
             <RecentTransactions />
         </div>

--- a/apps/web/src/routes/manage-escrow.tsx
+++ b/apps/web/src/routes/manage-escrow.tsx
@@ -1,38 +1,584 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { Badge, Button } from '@solana/design-system';
+import {
+    Ban,
+    Clock3,
+    Coins,
+    FileText,
+    KeyRound,
+    ListX,
+    LockKeyhole,
+    RefreshCw,
+    ShieldCheck,
+    SlidersHorizontal,
+    Undo2,
+    UserCheck,
+    Webhook,
+} from 'lucide-react';
+
 import { QuickDefaults } from '@/components/QuickDefaults';
 import { RecentTransactions } from '@/components/RecentTransactions';
+import { WalletButton } from '@/components/solana/solana-provider';
+import { AddTimelock } from '@/components/instructions/AddTimelock';
+import { AllowMint } from '@/components/instructions/AllowMint';
 import { BlockMint } from '@/components/instructions/BlockMint';
+import { BlockTokenExtension } from '@/components/instructions/BlockTokenExtension';
 import { RemoveExtension } from '@/components/instructions/RemoveExtension';
+import { SetArbiter } from '@/components/instructions/SetArbiter';
+import { SetHook } from '@/components/instructions/SetHook';
 import { SetImmutable } from '@/components/instructions/SetImmutable';
 import { UnblockTokenExtension } from '@/components/instructions/UnblockTokenExtension';
 import { UpdateAdmin } from '@/components/instructions/UpdateAdmin';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { useWallet } from '@/contexts/WalletContext';
+import { useSavedValues } from '@/contexts/SavedValuesContext';
+import { useEscrowDashboardData } from '@/hooks/use-escrow-accounts';
+import {
+    formatAddress,
+    formatTokenAmount,
+    type AllowedMintRecord,
+    type EscrowExtensionsRecord,
+    type EscrowRecord,
+    type ReceiptRecord,
+} from '@/lib/escrow-model';
 
-import { InstructionPanel } from './instruction-panel';
+type ManageAction =
+    | 'add-timelock'
+    | 'allow-mint'
+    | 'block-mint'
+    | 'block-token-extension'
+    | 'remove-extension'
+    | 'set-arbiter'
+    | 'set-hook'
+    | 'set-immutable'
+    | 'unblock-token-extension'
+    | 'update-admin';
+
+type DialogStep = 'confirm' | 'form';
+
+const ACTION_LABELS: Record<ManageAction, string> = {
+    'add-timelock': 'Add Timelock',
+    'allow-mint': 'Allow Mint',
+    'block-mint': 'Block Mint',
+    'block-token-extension': 'Block Token Extension',
+    'remove-extension': 'Remove Extension',
+    'set-arbiter': 'Set Arbiter',
+    'set-hook': 'Set Hook',
+    'set-immutable': 'Set Immutable',
+    'unblock-token-extension': 'Unblock Token Extension',
+    'update-admin': 'Update Admin',
+};
+
+function actionDescription(action: ManageAction) {
+    if (action === 'allow-mint') return 'Permit a mint for deposits into this escrow.';
+    if (action === 'block-mint') return 'Remove an allowed mint account and return its rent.';
+    if (action === 'add-timelock') return 'Set the lock duration applied to new receipt withdrawals.';
+    if (action === 'set-hook') return 'Configure a hook program invoked during escrow operations.';
+    if (action === 'set-arbiter') return 'Require your connected wallet to co-sign withdrawals.';
+    if (action === 'block-token-extension') return 'Block a Token-2022 extension from future deposits.';
+    if (action === 'unblock-token-extension') return 'Remove an extension from the blocked list.';
+    if (action === 'remove-extension') return 'Remove a configured escrow extension.';
+    if (action === 'set-immutable') return 'Permanently lock escrow configuration.';
+    return 'Update the admin authority using your connected wallet.';
+}
+
+function formatDuration(seconds: bigint) {
+    if (seconds === 0n) return 'Disabled';
+    const days = seconds / 86_400n;
+    if (days > 0n && seconds % 86_400n === 0n) return `${days.toString()}d`;
+    const hours = seconds / 3_600n;
+    if (hours > 0n && seconds % 3_600n === 0n) return `${hours.toString()}h`;
+    return `${seconds.toString()}s`;
+}
+
+function escrowStatus(escrow: EscrowRecord, extensions: EscrowExtensionsRecord | null) {
+    if (escrow.isImmutable) return <Badge variant="warning">Immutable</Badge>;
+    if (extensions && extensions.extensionCount > 0) return <Badge variant="info">Configured</Badge>;
+    return <Badge variant="success">Mutable</Badge>;
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="text-xs text-muted-foreground">{label}</p>
+            <p className="truncate font-mono text-xs text-foreground">{value}</p>
+        </div>
+    );
+}
+
+function ActionSummary({
+    allowedMints,
+    escrow,
+    extensions,
+    receipts,
+}: {
+    allowedMints: readonly AllowedMintRecord[];
+    escrow: EscrowRecord;
+    extensions: EscrowExtensionsRecord | null;
+    receipts: readonly ReceiptRecord[];
+}) {
+    return (
+        <div className="grid gap-3 rounded-lg border border-sand-300 bg-sand-100 p-3 text-sm">
+            <DetailRow label="Escrow" value={escrow.address} />
+            <DetailRow label="Admin" value={escrow.admin} />
+            <div className="grid grid-cols-2 gap-3">
+                <div>
+                    <p className="text-xs text-muted-foreground">Receipts</p>
+                    <p className="font-semibold tabular-nums">{receipts.length}</p>
+                </div>
+                <div>
+                    <p className="text-xs text-muted-foreground">Allowed Mints</p>
+                    <p className="font-semibold tabular-nums">{allowedMints.length}</p>
+                </div>
+                <div>
+                    <p className="text-xs text-muted-foreground">Extensions</p>
+                    <p className="font-semibold tabular-nums">{extensions?.extensionCount ?? 0}</p>
+                </div>
+                <div>
+                    <p className="text-xs text-muted-foreground">Lock Duration</p>
+                    <p className="font-semibold tabular-nums">
+                        {extensions?.lockDuration ? formatDuration(extensions.lockDuration) : 'None'}
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function ImmutableConfirmation({
+    escrow,
+    onCancel,
+    onContinue,
+}: {
+    escrow: EscrowRecord;
+    onCancel: () => void;
+    onContinue: () => void;
+}) {
+    return (
+        <div className="space-y-4">
+            <DialogHeader>
+                <DialogTitle className="text-destructive">Set Immutable</DialogTitle>
+                <DialogDescription>
+                    This permanently prevents future escrow configuration changes for {formatAddress(escrow.address)}.
+                </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+                <Button type="button" variant="secondary" onClick={onCancel}>
+                    Cancel
+                </Button>
+                <Button
+                    type="button"
+                    className="bg-destructive text-white hover:bg-destructive/90"
+                    onClick={onContinue}
+                >
+                    Continue
+                </Button>
+            </DialogFooter>
+        </div>
+    );
+}
+
+function ManageDialog({
+    action,
+    allowedMints,
+    escrow,
+    extensions,
+    onOpenChange,
+    onSuccess,
+    receipts,
+}: {
+    action: ManageAction | null;
+    allowedMints: readonly AllowedMintRecord[];
+    escrow: EscrowRecord;
+    extensions: EscrowExtensionsRecord | null;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+    receipts: readonly ReceiptRecord[];
+}) {
+    const open = action !== null;
+    const [step, setStep] = useState<DialogStep>('confirm');
+    const title = action ? ACTION_LABELS[action] : '';
+    const firstBlockedExtension = extensions?.blockedTokenExtensions[0]?.toString() ?? '5';
+    const firstExtensionType = extensions?.extensions[0]?.rawType.toString() ?? '0';
+
+    function closeDialog(nextOpen: boolean) {
+        if (!nextOpen) setStep('confirm');
+        onOpenChange(nextOpen);
+    }
+
+    function handleSuccess() {
+        onSuccess();
+        closeDialog(false);
+    }
+
+    function form() {
+        if (!action) return null;
+        const props = {
+            initialEscrow: escrow.address,
+            onSuccess: handleSuccess,
+            submitLabel: title,
+        };
+
+        if (action === 'update-admin')
+            return <UpdateAdmin key={`${escrow.address}-update-admin`} hideKnownFields {...props} />;
+        if (action === 'set-immutable')
+            return <SetImmutable key={`${escrow.address}-immutable`} hideKnownFields {...props} />;
+        if (action === 'allow-mint') return <AllowMint key={`${escrow.address}-allow-mint`} {...props} />;
+        if (action === 'block-mint') return <BlockMint key={`${escrow.address}-block-mint`} {...props} />;
+        if (action === 'add-timelock')
+            return <AddTimelock key={`${escrow.address}-timelock`} hideKnownFields {...props} />;
+        if (action === 'set-hook') return <SetHook key={`${escrow.address}-hook`} hideKnownFields {...props} />;
+        if (action === 'set-arbiter')
+            return <SetArbiter key={`${escrow.address}-arbiter`} hideKnownFields {...props} />;
+        if (action === 'block-token-extension') {
+            return <BlockTokenExtension key={`${escrow.address}-block-extension`} hideKnownFields {...props} />;
+        }
+        if (action === 'unblock-token-extension') {
+            return (
+                <UnblockTokenExtension
+                    key={`${escrow.address}-unblock-extension`}
+                    hideKnownFields
+                    initialExtensionType={firstBlockedExtension}
+                    {...props}
+                />
+            );
+        }
+        return (
+            <RemoveExtension
+                key={`${escrow.address}-remove-extension`}
+                hideKnownFields
+                initialExtensionType={firstExtensionType}
+                {...props}
+            />
+        );
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={closeDialog}>
+            {action && (
+                <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+                    {action === 'set-immutable' && step === 'confirm' ? (
+                        <ImmutableConfirmation
+                            escrow={escrow}
+                            onCancel={() => closeDialog(false)}
+                            onContinue={() => setStep('form')}
+                        />
+                    ) : (
+                        <>
+                            <DialogHeader>
+                                <DialogTitle>{title}</DialogTitle>
+                                <DialogDescription>{actionDescription(action)}</DialogDescription>
+                            </DialogHeader>
+                            <ActionSummary
+                                allowedMints={allowedMints}
+                                escrow={escrow}
+                                extensions={extensions}
+                                receipts={receipts}
+                            />
+                            {form()}
+                        </>
+                    )}
+                </DialogContent>
+            )}
+        </Dialog>
+    );
+}
+
+function Metric({
+    icon: Icon,
+    label,
+    value,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    value: string;
+}) {
+    return (
+        <div className="rounded-lg border border-sand-300 bg-sand-100 p-3">
+            <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+            </div>
+            <p className="truncate font-semibold tabular-nums text-foreground">{value}</p>
+        </div>
+    );
+}
+
+function EscrowCard({
+    allowedMints,
+    escrow,
+    extensions,
+    onRefresh,
+    receipts,
+}: {
+    allowedMints: readonly AllowedMintRecord[];
+    escrow: EscrowRecord;
+    extensions: EscrowExtensionsRecord | null;
+    onRefresh: () => void;
+    receipts: readonly ReceiptRecord[];
+}) {
+    const [action, setAction] = useState<ManageAction | null>(null);
+    const depositedAmount = receipts.reduce((sum, receipt) => sum + receipt.amount, 0n);
+    const blockedCount = extensions?.blockedTokenExtensions.length ?? 0;
+    const canEdit = !escrow.isImmutable;
+
+    return (
+        <>
+            <Card className="border-0 border-all-dashed-medium bg-card transition-colors hover:bg-sand-100">
+                <CardContent className="space-y-4 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 items-center gap-2">
+                            <ShieldCheck className="h-4 w-4 shrink-0 text-sand-1100" />
+                            <div className="min-w-0">
+                                <p className="font-semibold text-foreground">Escrow</p>
+                                <p className="truncate font-mono text-xs text-muted-foreground">
+                                    {formatAddress(escrow.address)}
+                                </p>
+                            </div>
+                        </div>
+                        {escrowStatus(escrow, extensions)}
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                        <Metric icon={Coins} label="Allowed Mints" value={allowedMints.length.toString()} />
+                        <Metric icon={FileText} label="Receipts" value={receipts.length.toString()} />
+                        <Metric
+                            icon={Clock3}
+                            label="Timelock"
+                            value={extensions?.lockDuration ? formatDuration(extensions.lockDuration) : 'None'}
+                        />
+                        <Metric icon={Ban} label="Blocked Exts" value={blockedCount.toString()} />
+                    </div>
+
+                    <div className="space-y-2 text-sm">
+                        <DetailRow label="Admin" value={escrow.admin} />
+                        <DetailRow label="Deposited by wallet" value={formatTokenAmount(depositedAmount)} />
+                        {extensions?.hookProgram && <DetailRow label="Hook Program" value={extensions.hookProgram} />}
+                        {extensions?.arbiter && <DetailRow label="Arbiter" value={extensions.arbiter} />}
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<UserCheck />}
+                            onClick={() => setAction('update-admin')}
+                        >
+                            Update Admin
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<LockKeyhole />}
+                            onClick={() => setAction('set-immutable')}
+                            disabled={!canEdit}
+                        >
+                            Set Immutable
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<Coins />}
+                            onClick={() => setAction('allow-mint')}
+                            disabled={!canEdit}
+                        >
+                            Allow Mint
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<Ban />}
+                            onClick={() => setAction('block-mint')}
+                            disabled={!canEdit}
+                        >
+                            Block Mint
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<Clock3 />}
+                            onClick={() => setAction('add-timelock')}
+                            disabled={!canEdit}
+                        >
+                            Add Timelock
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<Webhook />}
+                            onClick={() => setAction('set-hook')}
+                            disabled={!canEdit}
+                        >
+                            Set Hook
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<KeyRound />}
+                            onClick={() => setAction('set-arbiter')}
+                            disabled={!canEdit}
+                        >
+                            Set Arbiter
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<ListX />}
+                            onClick={() => setAction('block-token-extension')}
+                            disabled={!canEdit}
+                        >
+                            Block Extension
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<Undo2 />}
+                            onClick={() => setAction('unblock-token-extension')}
+                            disabled={!canEdit || blockedCount === 0}
+                        >
+                            Unblock Extension
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            iconLeft={<SlidersHorizontal />}
+                            onClick={() => setAction('remove-extension')}
+                            disabled={!canEdit || !extensions?.extensionCount}
+                        >
+                            Remove Extension
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+            <ManageDialog
+                action={action}
+                allowedMints={allowedMints}
+                escrow={escrow}
+                extensions={extensions}
+                onOpenChange={open => !open && setAction(null)}
+                onSuccess={onRefresh}
+                receipts={receipts}
+            />
+        </>
+    );
+}
+
+function EmptyManagedEscrows() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
+            <ShieldCheck className="h-8 w-8 text-sand-1000" />
+            <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-foreground">No managed escrows</h2>
+                <p className="text-sm text-muted-foreground">Create an escrow first, then manage configuration here.</p>
+            </div>
+            <Link
+                to="/create"
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+                Create Escrow
+            </Link>
+        </div>
+    );
+}
 
 export function ManageEscrowRoute() {
+    const { connected } = useWallet();
+    const { mints } = useSavedValues();
+    const dashboard = useEscrowDashboardData(mints);
+    const data = dashboard.data;
+    const escrows = data?.adminEscrows ?? [];
+    const allowedMints = data?.allowedMints ?? [];
+    const receipts = data?.escrowReceipts ?? [];
+    const dataError = dashboard.error instanceof Error ? dashboard.error.message : null;
+
+    if (!connected) {
+        return (
+            <div className="mx-auto max-w-3xl space-y-6">
+                <h1 className="text-3xl font-semibold tracking-tight text-foreground">Manage Escrow</h1>
+                <Card className="border-0 border-all-dashed-medium bg-card">
+                    <CardContent className="flex flex-col items-center justify-center gap-4 py-14 text-center">
+                        <p className="text-sm text-muted-foreground">Connect wallet to load managed escrows.</p>
+                        <WalletButton />
+                    </CardContent>
+                </Card>
+                <QuickDefaults />
+            </div>
+        );
+    }
+
     return (
         <div className="space-y-6">
-            <div>
-                <h1 className="text-2xl font-semibold tracking-tight text-foreground">Manage Escrow</h1>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+                <h1 className="text-3xl font-semibold tracking-tight text-foreground">Manage Escrow</h1>
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    iconLeft={<RefreshCw className={dashboard.isFetching ? 'animate-spin' : ''} />}
+                    onClick={() => void dashboard.refetch()}
+                    disabled={dashboard.isFetching}
+                >
+                    Refresh
+                </Button>
             </div>
+
+            <Card className="relative overflow-hidden border-0 border-all-dashed-medium bg-card">
+                <CardHeader className="pb-4">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-2">
+                            <ShieldCheck className="h-5 w-5 text-foreground" />
+                            <CardTitle>Managed Escrows</CardTitle>
+                        </div>
+                        {escrows.length > 0 && <Badge variant="success">{escrows.length}</Badge>}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {dataError ? (
+                        <div className="py-6 text-sm text-destructive">{dataError}</div>
+                    ) : dashboard.isLoading ? (
+                        <div className="flex items-center justify-center py-12 text-muted-foreground">
+                            Loading escrows...
+                        </div>
+                    ) : escrows.length > 0 ? (
+                        <div className="grid gap-4 lg:grid-cols-2">
+                            {escrows.map(escrow => (
+                                <EscrowCard
+                                    key={escrow.address}
+                                    allowedMints={allowedMints.filter(record => record.escrow === escrow.address)}
+                                    escrow={escrow}
+                                    extensions={data?.extensions.get(escrow.address) ?? null}
+                                    onRefresh={() => void dashboard.refetch()}
+                                    receipts={receipts.filter(receipt => receipt.escrow === escrow.address)}
+                                />
+                            ))}
+                        </div>
+                    ) : (
+                        <EmptyManagedEscrows />
+                    )}
+                </CardContent>
+            </Card>
+
             <QuickDefaults />
             <RecentTransactions />
-            <div className="grid gap-4 lg:grid-cols-2">
-                <InstructionPanel title="Update Admin">
-                    <UpdateAdmin />
-                </InstructionPanel>
-                <InstructionPanel title="Set Immutable">
-                    <SetImmutable />
-                </InstructionPanel>
-                <InstructionPanel title="Block Mint">
-                    <BlockMint />
-                </InstructionPanel>
-                <InstructionPanel title="Unblock Token Extension">
-                    <UnblockTokenExtension />
-                </InstructionPanel>
-                <InstructionPanel title="Remove Extension">
-                    <RemoveExtension />
-                </InstructionPanel>
-            </div>
         </div>
     );
 }

--- a/apps/web/src/routes/operate-escrow.tsx
+++ b/apps/web/src/routes/operate-escrow.tsx
@@ -1,26 +1,434 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import { Badge, Button } from '@solana/design-system';
+import { ArrowRightLeft, Clock3, Coins, FileText, Plus, RefreshCw, ShieldCheck, WalletCards } from 'lucide-react';
+
 import { QuickDefaults } from '@/components/QuickDefaults';
 import { RecentTransactions } from '@/components/RecentTransactions';
 import { Deposit } from '@/components/instructions/Deposit';
 import { Withdraw } from '@/components/instructions/Withdraw';
+import { WalletButton } from '@/components/solana/solana-provider';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useSavedValues } from '@/contexts/SavedValuesContext';
+import { useWallet } from '@/contexts/WalletContext';
+import { useEscrowDashboardData } from '@/hooks/use-escrow-accounts';
+import {
+    formatAddress,
+    formatTokenAmount,
+    isReceiptWithdrawable,
+    receiptUnlockTimestamp,
+    type AllowedMintRecord,
+    type EscrowExtensionsRecord,
+    type EscrowRecord,
+    type ReceiptRecord,
+} from '@/lib/escrow-model';
 
-import { InstructionPanel } from './instruction-panel';
+type OperateAction = 'deposit' | 'withdraw';
+
+interface DepositTarget {
+    allowedMints: readonly AllowedMintRecord[];
+    escrow: EscrowRecord | null;
+    escrowAddress: string;
+    receipts: readonly ReceiptRecord[];
+}
+
+function formatTimestamp(value: bigint) {
+    return new Intl.DateTimeFormat('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(Number(value) * 1000));
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="text-xs text-muted-foreground">{label}</p>
+            <p className="truncate font-mono text-xs text-foreground">{value}</p>
+        </div>
+    );
+}
+
+function Metric({
+    icon: Icon,
+    label,
+    value,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    value: string;
+}) {
+    return (
+        <div className="rounded-lg border border-sand-300 bg-sand-100 p-3">
+            <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+            </div>
+            <p className="truncate font-semibold tabular-nums text-foreground">{value}</p>
+        </div>
+    );
+}
+
+function OperationDialog({
+    action,
+    initialAmount = '',
+    initialEscrow = '',
+    initialMint = '',
+    initialReceipt = '',
+    onOpenChange,
+    onSuccess,
+    open,
+}: {
+    action: OperateAction;
+    initialAmount?: string;
+    initialEscrow?: string;
+    initialMint?: string;
+    initialReceipt?: string;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+    open: boolean;
+}) {
+    const isDeposit = action === 'deposit';
+    const title = isDeposit ? 'Deposit Tokens' : 'Withdraw Tokens';
+
+    function handleSuccess() {
+        onSuccess();
+        onOpenChange(false);
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>
+                        {isDeposit
+                            ? 'Escrow and mint fields are prefilled when this action comes from a known escrow target.'
+                            : 'Escrow, mint, and receipt are selected from the receipt card.'}
+                    </DialogDescription>
+                </DialogHeader>
+                {isDeposit ? (
+                    <Deposit
+                        key={`${initialEscrow}-${initialMint}-deposit`}
+                        hideKnownFields={Boolean(initialEscrow && initialMint)}
+                        initialAmount={initialAmount}
+                        initialEscrow={initialEscrow}
+                        initialMint={initialMint}
+                        onSuccess={handleSuccess}
+                        submitLabel="Deposit Tokens"
+                    />
+                ) : (
+                    <Withdraw
+                        key={`${initialReceipt}-withdraw`}
+                        hideKnownFields={Boolean(initialEscrow && initialMint && initialReceipt)}
+                        initialEscrow={initialEscrow}
+                        initialMint={initialMint}
+                        initialReceipt={initialReceipt}
+                        onSuccess={handleSuccess}
+                        submitLabel="Withdraw Tokens"
+                    />
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function DepositTargetCard({ onRefresh, target }: { onRefresh: () => void; target: DepositTarget }) {
+    const [open, setOpen] = useState(false);
+    const preferredMint = target.allowedMints[0]?.mint ?? '';
+    const configured = target.escrow ? target.escrow.isImmutable : false;
+
+    return (
+        <>
+            <Card className="border-0 border-all-dashed-medium bg-card transition-colors hover:bg-sand-100">
+                <CardContent className="space-y-4 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 items-center gap-2">
+                            <ShieldCheck className="h-4 w-4 shrink-0 text-sand-1100" />
+                            <div className="min-w-0">
+                                <p className="font-semibold text-foreground">Deposit Target</p>
+                                <p className="truncate font-mono text-xs text-muted-foreground">
+                                    {formatAddress(target.escrowAddress)}
+                                </p>
+                            </div>
+                        </div>
+                        <Badge variant={configured ? 'warning' : 'info'}>{configured ? 'Immutable' : 'Open'}</Badge>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                        <Metric icon={Coins} label="Known Mints" value={target.allowedMints.length.toString()} />
+                        <Metric icon={FileText} label="Receipts" value={target.receipts.length.toString()} />
+                    </div>
+
+                    <div className="space-y-2 text-sm">
+                        {target.escrow?.admin && <DetailRow label="Admin" value={target.escrow.admin} />}
+                        {preferredMint && <DetailRow label="Default Mint" value={preferredMint} />}
+                    </div>
+
+                    <Button type="button" size="sm" iconLeft={<Plus />} onClick={() => setOpen(true)}>
+                        Deposit
+                    </Button>
+                </CardContent>
+            </Card>
+            <OperationDialog
+                action="deposit"
+                initialEscrow={target.escrowAddress}
+                initialMint={preferredMint}
+                onOpenChange={setOpen}
+                onSuccess={onRefresh}
+                open={open}
+            />
+        </>
+    );
+}
+
+function ReceiptCard({
+    extensions,
+    onRefresh,
+    receipt,
+}: {
+    extensions: EscrowExtensionsRecord | null;
+    onRefresh: () => void;
+    receipt: ReceiptRecord;
+}) {
+    const [open, setOpen] = useState(false);
+    const unlockTimestamp = receiptUnlockTimestamp(receipt, extensions);
+    const withdrawable = isReceiptWithdrawable(receipt, extensions);
+
+    return (
+        <>
+            <Card className="border-0 border-all-dashed-medium bg-card transition-colors hover:bg-sand-100">
+                <CardContent className="space-y-4 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 items-center gap-2">
+                            <WalletCards className="h-4 w-4 shrink-0 text-sand-1100" />
+                            <div className="min-w-0">
+                                <p className="font-semibold text-foreground">Receipt</p>
+                                <p className="truncate font-mono text-xs text-muted-foreground">
+                                    {formatAddress(receipt.address)}
+                                </p>
+                            </div>
+                        </div>
+                        <Badge variant={withdrawable ? 'success' : 'warning'}>
+                            {withdrawable ? 'Withdrawable' : 'Locked'}
+                        </Badge>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                        <Metric icon={Coins} label="Amount" value={formatTokenAmount(receipt.amount)} />
+                        <Metric
+                            icon={Clock3}
+                            label="Unlock"
+                            value={unlockTimestamp ? formatTimestamp(unlockTimestamp) : 'Now'}
+                        />
+                    </div>
+
+                    <div className="space-y-2 text-sm">
+                        <DetailRow label="Escrow" value={receipt.escrow} />
+                        <DetailRow label="Mint" value={receipt.mint} />
+                        <DetailRow label="Deposited" value={formatTimestamp(receipt.depositedAt)} />
+                    </div>
+
+                    <Button type="button" size="sm" disabled={!withdrawable} onClick={() => setOpen(true)}>
+                        Withdraw
+                    </Button>
+                </CardContent>
+            </Card>
+            <OperationDialog
+                action="withdraw"
+                initialEscrow={receipt.escrow}
+                initialMint={receipt.mint}
+                initialReceipt={receipt.address}
+                onOpenChange={setOpen}
+                onSuccess={onRefresh}
+                open={open}
+            />
+        </>
+    );
+}
+
+function EmptyState({ action, description, title }: { action: React.ReactNode; description: string; title: string }) {
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
+            <ArrowRightLeft className="h-8 w-8 text-sand-1000" />
+            <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+                <p className="text-sm text-muted-foreground">{description}</p>
+            </div>
+            {action}
+        </div>
+    );
+}
 
 export function OperateEscrowRoute() {
+    const { connected } = useWallet();
+    const { defaultEscrow, defaultMint, mints } = useSavedValues();
+    const dashboard = useEscrowDashboardData(mints);
+    const data = dashboard.data;
+    const [manualDepositOpen, setManualDepositOpen] = useState(false);
+    const [manualWithdrawOpen, setManualWithdrawOpen] = useState(false);
+
+    const depositTargets = useMemo<DepositTarget[]>(() => {
+        const escrows = data?.adminEscrows ?? [];
+        const allowedMints = data?.allowedMints ?? [];
+        const receipts = data?.escrowReceipts ?? [];
+        const targets: DepositTarget[] = escrows.map(escrow => ({
+            allowedMints: allowedMints.filter(record => record.escrow === escrow.address),
+            escrow,
+            escrowAddress: escrow.address,
+            receipts: receipts.filter(receipt => receipt.escrow === escrow.address),
+        }));
+        if (defaultEscrow && !targets.some(target => target.escrowAddress === defaultEscrow)) {
+            targets.unshift({
+                allowedMints: allowedMints.filter(record => record.escrow === defaultEscrow),
+                escrow: null,
+                escrowAddress: defaultEscrow,
+                receipts: receipts.filter(receipt => receipt.escrow === defaultEscrow),
+            });
+        }
+        return targets;
+    }, [data, defaultEscrow]);
+
+    const receipts = data?.depositorReceipts ?? [];
+    const dataError = dashboard.error instanceof Error ? dashboard.error.message : null;
+
+    if (!connected) {
+        return (
+            <div className="mx-auto max-w-3xl space-y-6">
+                <h1 className="text-3xl font-semibold tracking-tight text-foreground">Deposit / Withdraw</h1>
+                <Card className="border-0 border-all-dashed-medium bg-card">
+                    <CardContent className="flex flex-col items-center justify-center gap-4 py-14 text-center">
+                        <WalletCards className="h-8 w-8 text-sand-1000" />
+                        <p className="text-sm text-muted-foreground">Connect wallet to load receipts and escrows.</p>
+                        <WalletButton />
+                    </CardContent>
+                </Card>
+                <QuickDefaults />
+            </div>
+        );
+    }
+
     return (
         <div className="space-y-6">
-            <div>
-                <h1 className="text-2xl font-semibold tracking-tight text-foreground">Deposit / Withdraw</h1>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+                <h1 className="text-3xl font-semibold tracking-tight text-foreground">Deposit / Withdraw</h1>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" size="sm" variant="secondary" onClick={() => setManualDepositOpen(true)}>
+                        Manual Deposit
+                    </Button>
+                    <Button type="button" size="sm" variant="secondary" onClick={() => setManualWithdrawOpen(true)}>
+                        Manual Withdraw
+                    </Button>
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        iconLeft={<RefreshCw className={dashboard.isFetching ? 'animate-spin' : ''} />}
+                        onClick={() => void dashboard.refetch()}
+                        disabled={dashboard.isFetching}
+                    >
+                        Refresh
+                    </Button>
+                </div>
             </div>
+
+            <Card className="border-0 border-all-dashed-medium bg-card">
+                <CardHeader className="pb-4">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-2">
+                            <Coins className="h-5 w-5 text-foreground" />
+                            <CardTitle>Deposit Targets</CardTitle>
+                        </div>
+                        {depositTargets.length > 0 && <Badge variant="success">{depositTargets.length}</Badge>}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {dataError ? (
+                        <div className="py-6 text-sm text-destructive">{dataError}</div>
+                    ) : dashboard.isLoading ? (
+                        <div className="flex items-center justify-center py-12 text-muted-foreground">
+                            Loading escrows...
+                        </div>
+                    ) : depositTargets.length > 0 ? (
+                        <div className="grid gap-4 lg:grid-cols-2">
+                            {depositTargets.map(target => (
+                                <DepositTargetCard
+                                    key={target.escrowAddress}
+                                    target={target}
+                                    onRefresh={() => void dashboard.refetch()}
+                                />
+                            ))}
+                        </div>
+                    ) : (
+                        <EmptyState
+                            title="No deposit targets"
+                            description="Create or save an escrow address to make deposit actions contextual."
+                            action={
+                                <Button asChild variant="secondary">
+                                    <Link to="/create">Create Escrow</Link>
+                                </Button>
+                            }
+                        />
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card className="border-0 border-all-dashed-medium bg-card">
+                <CardHeader className="pb-4">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-2">
+                            <FileText className="h-5 w-5 text-foreground" />
+                            <CardTitle>My Receipts</CardTitle>
+                        </div>
+                        {receipts.length > 0 && <Badge variant="success">{receipts.length}</Badge>}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {dashboard.isLoading ? (
+                        <div className="flex items-center justify-center py-12 text-muted-foreground">
+                            Loading receipts...
+                        </div>
+                    ) : receipts.length > 0 ? (
+                        <div className="grid gap-4 lg:grid-cols-2">
+                            {receipts.map(receipt => (
+                                <ReceiptCard
+                                    key={receipt.address}
+                                    extensions={data?.extensions.get(receipt.escrow) ?? null}
+                                    receipt={receipt}
+                                    onRefresh={() => void dashboard.refetch()}
+                                />
+                            ))}
+                        </div>
+                    ) : (
+                        <EmptyState
+                            title="No receipts"
+                            description="Deposit tokens first, then withdraw from receipt cards when they are ready."
+                            action={
+                                <Button type="button" variant="secondary" onClick={() => setManualDepositOpen(true)}>
+                                    Deposit Tokens
+                                </Button>
+                            }
+                        />
+                    )}
+                </CardContent>
+            </Card>
+
+            <OperationDialog
+                action="deposit"
+                initialEscrow={defaultEscrow}
+                initialMint={defaultMint}
+                onOpenChange={setManualDepositOpen}
+                onSuccess={() => void dashboard.refetch()}
+                open={manualDepositOpen}
+            />
+            <OperationDialog
+                action="withdraw"
+                onOpenChange={setManualWithdrawOpen}
+                onSuccess={() => void dashboard.refetch()}
+                open={manualWithdrawOpen}
+            />
             <QuickDefaults />
             <RecentTransactions />
-            <div className="grid gap-4 lg:grid-cols-2">
-                <InstructionPanel title="Deposit">
-                    <Deposit />
-                </InstructionPanel>
-                <InstructionPanel title="Withdraw">
-                    <Withdraw />
-                </InstructionPanel>
-            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add escrow account model helpers and read-only RPC fetchers
- add React Query hooks for escrows, receipts, extensions, and known allowed mints
- refactor escrow instruction forms to accept initial values, hidden known fields, custom submit labels, and success callbacks
- add wallet-aware dashboard cards backed by escrow account data
- add managed escrow cards with prefilled action dialogs
- add contextual deposit target and receipt withdraw flows
- centralize escrow transaction mutations with shared toasts, recent transaction logging, and query invalidation

## Test Plan
- pnpm --filter @solana/escrow-program-web typecheck
- pnpm lint
- pnpm run format:check
- just check
- pnpm --filter @solana/escrow-program-web build