### PR TITLE
ci: pin release build toolchain

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,9 +23,9 @@ inputs:
     required: false
     default: 'true'
   solana-version:
-    description: "Solana CLI version to install (e.g., 'stable', 'v1.18.23')"
+    description: "Solana CLI version to install (e.g., 'v4.0.0')"
     required: false
-    default: 'stable'
+    default: 'v4.0.0'
 
 runs:
   using: 'composite'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust-cache-key: 'release-${{ inputs.network }}'
-          solana-version: 'stable'
+          solana-version: 'v4.0.0'
 
       - name: Install solana-verify
         run: cargo install solana-verify --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ resolver = "2"
 version = "0.0.1"
 edition = "2021"
 
+[workspace.metadata.cli]
+solana = "3.1.10"
+
 [workspace.lints.rust]
 unused_imports = "deny"
 dead_code = "warn"


### PR DESCRIPTION
## Summary
- pin the release workflow Solana CLI install to v4.0.0
- default the shared setup action to v4.0.0 for future release jobs
- add workspace Solana CLI metadata so solana-verify uses the newer 3.1.10 verifiable build image

## Test Plan
- pnpm run format:check
- just check