### PR TITLE
ci: add dependency audits and miri

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,6 +2,18 @@ name: 'Setup CI Environment'
 description: 'Shared setup for Rust, Solana, pnpm, and optional surfpool'
 
 inputs:
+  install-rust:
+    description: 'Install Rust toolchain'
+    required: false
+    default: 'true'
+  rust-toolchain:
+    description: 'Rust toolchain to install'
+    required: false
+    default: '1.92'
+  rust-components:
+    description: 'Rust components to install'
+    required: false
+    default: 'rustfmt, clippy'
   enable-rust-cache:
     description: 'Enable Rust caching (restore/save)'
     required: false
@@ -26,18 +38,31 @@ inputs:
     description: "Solana CLI version to install (e.g., 'v4.0.0')"
     required: false
     default: 'v4.0.0'
+  install-just:
+    description: 'Install just'
+    required: false
+    default: 'true'
+  install-pnpm:
+    description: 'Install pnpm and Node.js'
+    required: false
+    default: 'true'
+  install-pnpm-dependencies:
+    description: 'Install pnpm dependencies'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
   steps:
     - name: Setup Rust
+      if: inputs.install-rust == 'true'
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: '1.92'
-        components: rustfmt, clippy
+        toolchain: ${{ inputs.rust-toolchain }}
+        components: ${{ inputs.rust-components }}
 
     - name: Rust cache
-      if: inputs.enable-rust-cache == 'true'
+      if: inputs.install-rust == 'true' && inputs.enable-rust-cache == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: '. -> target'
@@ -78,24 +103,29 @@ runs:
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Install just
+      if: inputs.install-just == 'true'
       uses: extractions/setup-just@v4
       with:
         just-version: '1.50.0'
 
     - name: Install pnpm
+      if: inputs.install-pnpm == 'true'
       uses: pnpm/action-setup@v4
 
     - name: Setup Node.js
+      if: inputs.install-pnpm == 'true'
       uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
 
     - name: Get pnpm store directory
+      if: inputs.install-pnpm == 'true'
       id: pnpm-store
       shell: bash
       run: echo "path=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Cache pnpm store
+      if: inputs.install-pnpm == 'true'
       id: pnpm-cache
       uses: actions/cache@v4
       with:
@@ -105,6 +135,7 @@ runs:
           ${{ runner.os }}-pnpm-
 
     - name: Install pnpm dependencies
+      if: inputs.install-pnpm == 'true' && inputs.install-pnpm-dependencies == 'true'
       shell: bash
       run: pnpm install --frozen-lockfile
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: cargo
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,15 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-patch-days: 1
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch
     groups:
       cargo-non-major:
         applies-to: version-updates
         update-types:
           - minor
-          - patch
 
   - package-ecosystem: npm
     directory: '/'
@@ -22,13 +24,15 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-patch-days: 1
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch
     groups:
       npm-non-major:
         applies-to: version-updates
         update-types:
           - minor
-          - patch
 
   - package-ecosystem: github-actions
     directory: '/'
@@ -36,6 +40,10 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch
     groups:
       actions:
         patterns:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,64 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          install-solana: 'false'
+          install-just: 'false'
+          install-pnpm: 'false'
+          rust-cache-key: 'cargo-audit'
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit
+
+  pnpm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          install-rust: 'false'
+          enable-rust-cache: 'false'
+          install-solana: 'false'
+          install-just: 'false'
+          install-pnpm-dependencies: 'false'
+      - run: pnpm audit --ignore GHSA-848j-6mx2-7j84
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          rust-toolchain: 'nightly'
+          rust-components: 'miri'
+          install-solana: 'false'
+          install-just: 'false'
+          install-pnpm: 'false'
+          rust-cache-key: 'miri'
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/org.rust-lang.miri
+          key: miri-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo +nightly miri setup
+      - run: cargo +nightly miri test -p escrow-program

--- a/package.json
+++ b/package.json
@@ -61,7 +61,13 @@
             "minimatch@^9.0.0": "9.0.7",
             "picomatch@^2.0.0": "2.3.2",
             "picomatch@^4.0.0": "4.0.4",
-            "socket.io-parser@^4.0.0": "4.2.6"
+            "socket.io-parser@^4.0.0": "4.2.6",
+            "ws@^8.0.0": "8.20.1"
+        },
+        "auditConfig": {
+            "ignoreCves": [
+                "GHSA-848j-6mx2-7j84"
+            ]
         }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   picomatch@^2.0.0: 2.3.2
   picomatch@^4.0.0: 4.0.4
   socket.io-parser@^4.0.0: 4.2.6
+  ws@^8.0.0: 8.20.1
 
 importers:
 
@@ -4261,12 +4262,12 @@ packages:
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   isows@1.0.6:
     resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5980,30 +5981,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -10888,9 +10865,9 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isows@1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isows@1.0.6(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optional: true
 
   istanbul-lib-coverage@3.2.2: {}
@@ -12326,7 +12303,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.4
       uuid: 11.1.1
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
@@ -12817,9 +12794,9 @@ snapshots:
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.9.3)(zod@3.22.4)
-      isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isows: 1.0.6(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.6.7(typescript@5.9.3)(zod@3.22.4)
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12900,17 +12877,6 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-    optional: true
-
-  ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6


### PR DESCRIPTION
## Summary
- add Security workflow with cargo audit, pnpm audit, and Miri checks using the shared setup action
- move Dependabot package update cadence to weekly
- update ws through pnpm overrides and baseline the current exact unpatched npm advisory

## Test Plan
- ruby -e "require \"yaml\"; ARGV.each { |f| YAML.load_file(f) }" .github/dependabot.yml .github/workflows/security.yml .github/actions/setup/action.yml
- git diff --check
- cargo audit --no-fetch
- pnpm audit --ignore GHSA-848j-6mx2-7j84
- cargo +nightly miri test -p escrow-program