### PR TITLE
ci: gate pnpm audit on fixable advisories

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,44 +41,7 @@ jobs:
           install-solana: 'false'
           install-just: 'false'
           install-pnpm-dependencies: 'false'
-      - run: |
-          report="${RUNNER_TEMP:-/tmp}/pnpm-audit.json"
-          set +e
-          pnpm audit --json > "$report"
-          audit_status=$?
-          set -e
-          if [ "$audit_status" -eq 0 ]; then
-            exit 0
-          fi
-          node - "$report" <<'NODE'
-          const fs = require("node:fs");
-
-          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          const advisories = Object.values(report.advisories ?? {});
-          if (advisories.length === 0) {
-            process.exit(1);
-          }
-
-          const isFixable = (advisory) => {
-            const patchedVersions = advisory.patched_versions;
-            return patchedVersions && patchedVersions !== "<0.0.0";
-          };
-          const fixable = advisories.filter(isFixable);
-
-          for (const advisory of advisories.filter((advisory) => !isFixable(advisory))) {
-            const id = advisory.github_advisory_id ?? advisory.cves?.[0] ?? advisory.id;
-            console.log(`Ignoring unfixable advisory ${id}`);
-          }
-
-          if (fixable.length > 0) {
-            console.error("Fixable pnpm advisories found:");
-            for (const advisory of fixable) {
-              const id = advisory.github_advisory_id ?? advisory.cves?.[0] ?? advisory.id;
-              console.error(`- ${id}: ${advisory.module_name} patched by ${advisory.patched_versions}`);
-            }
-            process.exit(1);
-          }
-          NODE
+      - run: pnpm audit --ignore-unfixable
 
   miri:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,44 @@ jobs:
           install-solana: 'false'
           install-just: 'false'
           install-pnpm-dependencies: 'false'
-      - run: pnpm audit --ignore GHSA-848j-6mx2-7j84
+      - run: |
+          report="${RUNNER_TEMP:-/tmp}/pnpm-audit.json"
+          set +e
+          pnpm audit --json > "$report"
+          audit_status=$?
+          set -e
+          if [ "$audit_status" -eq 0 ]; then
+            exit 0
+          fi
+          node - "$report" <<'NODE'
+          const fs = require("node:fs");
+
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const advisories = Object.values(report.advisories ?? {});
+          if (advisories.length === 0) {
+            process.exit(1);
+          }
+
+          const isFixable = (advisory) => {
+            const patchedVersions = advisory.patched_versions;
+            return patchedVersions && patchedVersions !== "<0.0.0";
+          };
+          const fixable = advisories.filter(isFixable);
+
+          for (const advisory of advisories.filter((advisory) => !isFixable(advisory))) {
+            const id = advisory.github_advisory_id ?? advisory.cves?.[0] ?? advisory.id;
+            console.log(`Ignoring unfixable advisory ${id}`);
+          }
+
+          if (fixable.length > 0) {
+            console.error("Fixable pnpm advisories found:");
+            for (const advisory of fixable) {
+              const id = advisory.github_advisory_id ?? advisory.cves?.[0] ?? advisory.id;
+              console.error(`- ${id}: ${advisory.module_name} patched by ${advisory.patched_versions}`);
+            }
+            process.exit(1);
+          }
+          NODE
 
   miri:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -63,11 +63,6 @@
             "picomatch@^4.0.0": "4.0.4",
             "socket.io-parser@^4.0.0": "4.2.6",
             "ws@^8.0.0": "8.20.1"
-        },
-        "auditConfig": {
-            "ignoreCves": [
-                "GHSA-848j-6mx2-7j84"
-            ]
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the hard-coded pnpm audit advisory ignore with pnpm --ignore-unfixable
- remove package.json auditConfig metadata from the earlier audit baseline
- keep CI passing for current unpatched transitive advisories while failing on fixable ones

## Test Plan
- ruby YAML parse for .github/workflows/security.yml
- git diff --check