### PR TITLE
fix(verify): add verify-local recipe and Apple Silicon build notes

### DIFF
--- a/justfile
+++ b/justfile
@@ -120,12 +120,14 @@ check-solana-verify:
 
 # Verify mainnet deployment against repo (remote build via OtterSec)
 # Note: Remote verification (--remote) only works on mainnet
+# Apple Silicon (local builds without --remote): enable Docker/Colima Rosetta and
+# `export DOCKER_DEFAULT_PLATFORM=linux/amd64`. The pinned verify image is amd64-only,
+# so the SBF build fails on getrandom under arm64 emulation without it.
 verify-mainnet: check-solana-verify
     solana-verify verify-from-repo \
         https://github.com/solana-program/escrow \
         --program-id Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg \
         --library-name escrow_program \
-        --mount-path program \
         --remote \
         -um
 

--- a/justfile
+++ b/justfile
@@ -131,6 +131,9 @@ verify-mainnet: check-solana-verify
         --remote \
         -um
 
+verify-local: check-solana-verify
+    solana-verify build --library-name escrow_program
+
 # ******************************************************************************
 # Release
 # ******************************************************************************


### PR DESCRIPTION
## Summary
- Add `just verify-local` for a local verifiable build of the program library only, scoped via `--library-name escrow_program`.
- A bare `solana-verify build` SBF-compiles the whole workspace; `tests/integration-tests` and `clients/rust` pull `getrandom 0.2.17`, which has no `target_os = "solana"` backend and fails `cargo build-sbf` ("target is not supported").
- Also: drop `--mount-path` from `verify-mainnet` and note Apple Silicon local-build requirements (`DOCKER_DEFAULT_PLATFORM=linux/amd64`, amd64-only verify image).

## Test Plan
- `DOCKER_DEFAULT_PLATFORM=linux/amd64 just verify-local` → builds the program lib, no getrandom error.