### PR TITLE
chore: migrate repo refs to solana-foundation org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   PROGRAM: escrow_program
   PROGRAM_ID: Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg
-  REPO_URL: https://github.com/solana-program/escrow
+  REPO_URL: https://github.com/solana-foundation/escrow
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ Licensed under MIT. See [LICENSE](LICENSE) for details.
 ## Support
 
 - [**Solana StackExchange**](https://solana.stackexchange.com/) - tag `escrow-program`
-- [**Open an Issue**](https://github.com/solana-program/escrow/issues/new)
+- [**Open an Issue**](https://github.com/solana-foundation/escrow/issues/new)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,6 @@
 
 **DO NOT CREATE A GITHUB ISSUE** to report a security problem.
 
-Instead please use this [Report a Vulnerability](https://github.com/solana-program/escrow/security/advisories/new) link.
+Instead please use this [Report a Vulnerability](https://github.com/solana-foundation/escrow/security/advisories/new) link.
 Provide a helpful title and detailed description of the problem.
 Expect a response as fast as possible in the advisory, typically within 72 hours.

--- a/audits/AUDIT_STATUS.md
+++ b/audits/AUDIT_STATUS.md
@@ -7,7 +7,7 @@ Last updated: 2026-04-07
 - Auditor: Accretion
 - Report: `audits/2026-accretion-solana-foundation-escrow-audit-A26SFR3.pdf`
 - Audited-through commit: `36187ad52c7c03d11b13b6f1da9461f2f757cee2`
-- Compare unaudited delta: https://github.com/solana-program/escrow/compare/36187ad52c7c03d11b13b6f1da9461f2f757cee2...main
+- Compare unaudited delta: https://github.com/solana-foundation/escrow/compare/36187ad52c7c03d11b13b6f1da9461f2f757cee2...main
 
 Audit scope is commit-based. Commits after the audited-through SHA are considered unaudited until a new audit or mitigation review updates this file.
 

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 description = "Rust client for the Escrow Solana program"
 license = "MIT"
-repository = "https://github.com/solana-program/escrow"
+repository = "https://github.com/solana-foundation/escrow"
 readme = "../../README.md"
 include = ["Cargo.toml", "../../README.md", "src/**/*.rs"]
 

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/solana-program/escrow.git",
+        "url": "git+https://github.com/solana-foundation/escrow.git",
         "directory": "clients/typescript"
     },
     "type": "module",
@@ -26,9 +26,9 @@
     "peerDependencies": {
         "@solana/kit": "^6.9.0"
     },
-    "homepage": "https://github.com/solana-program/escrow#readme",
+    "homepage": "https://github.com/solana-foundation/escrow#readme",
     "bugs": {
-        "url": "https://github.com/solana-program/escrow/issues"
+        "url": "https://github.com/solana-foundation/escrow/issues"
     },
     "keywords": [
         "solana",

--- a/examples/typescript/escrow-demo/README.md
+++ b/examples/typescript/escrow-demo/README.md
@@ -312,4 +312,4 @@ If everything goes well, you should see the following output:
 ## Support
 
 - [**Solana StackExchange**](https://solana.stackexchange.com/) - tag `escrow-program`
-- [**Open an Issue**](https://github.com/solana-program/escrow/issues/new)
+- [**Open an Issue**](https://github.com/solana-foundation/escrow/issues/new)

--- a/justfile
+++ b/justfile
@@ -125,7 +125,7 @@ check-solana-verify:
 # so the SBF build fails on getrandom under arm64 emulation without it.
 verify-mainnet: check-solana-verify
     solana-verify verify-from-repo \
-        https://github.com/solana-program/escrow \
+        https://github.com/solana-foundation/escrow \
         --program-id Escrowae7RaUfNn4oEZHywMXE5zWzYCXenwrCDaEoifg \
         --library-name escrow_program \
         --remote \

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "main": "index.js",
     "description": "Escrow Program",
-    "repository": "git@github.com:solana-program/escrow.git",
+    "repository": "git@github.com:solana-foundation/escrow.git",
     "license": "MIT",
     "scripts": {
         "build": "cd clients/typescript && tsc",

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -37,8 +37,8 @@ use solana_security_txt::security_txt;
 #[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Escrow Program",
-    project_url: "https://github.com/solana-program/escrow",
-    contacts: "link:https://github.com/solana-program/escrow/security/advisories/new",
-    policy: "https://github.com/solana-program/escrow/security/policy",
-    source_code: "https://github.com/solana-program/escrow"
+    project_url: "https://github.com/solana-foundation/escrow",
+    contacts: "link:https://github.com/solana-foundation/escrow/security/advisories/new",
+    policy: "https://github.com/solana-foundation/escrow/security/policy",
+    source_code: "https://github.com/solana-foundation/escrow"
 }


### PR DESCRIPTION
## Summary
- Swap hardcoded `github.com/solana-program/escrow` URLs to `solana-foundation/escrow` (15 refs, 9 files): docs, package metadata, `security_txt!`, `release.yml` REPO_URL, verify recipe, audit + example links
- Exact-string swap only — ecosystem `@solana-program/*` deps and the external `solana-program/program-metadata` reference left untouched
- IDL + clients regenerate identically; `pnpm-lock.yaml` unchanged

## Test Plan
- `grep -rn 'solana-program/escrow'` (excl. vendored dirs) → 0 hits
- `just build` clean; `just integration-test` → 249 passed
- Base CI (test/format/idl/security) runs under the new org on this PR

## Follow-up (ops, not in this PR — path-bound, need manual re-point)
- crates.io + npm OIDC trusted publishers → new repo path
- Doppler OIDC service identity + org secrets/vars (`DOPPLER_SERVICE_IDENTITY_ID`, `SQUADS_VAULT`)
- On-chain: program upgrade ships new `security_txt`; `just verify-mainnet` re-points verify PDA