### PR TITLE
ci: add web build job to validate frontend on PRs

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - 'apps/web/**'
+      - 'pnpm-lock.yaml'
+      - '.nvmrc'
+      - '.github/workflows/web.yml'
 
 jobs:
   web-build:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,20 @@
+name: Web
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  web-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install
+      - name: Build web app
+        run: pnpm --filter @solana/escrow-program-web build


### PR DESCRIPTION
## Summary
- Add a `web-build` job (new `.github/workflows/web.yml`) that compiles `apps/web` on every PR.
- Closes a CI gap: `apps/web` was never built or typechecked in CI, so a frontend-only change could break the production build with nothing catching it.
- Node-only job (no Rust/Solana toolchain): `pnpm install` then `pnpm --filter @solana/escrow-program-web build`. The web app's `prebuild` hook generates + builds the `@solana/escrow` TS client from the committed IDL.

## Test Plan
Verified the full chain locally, including cold start (client artifacts removed → `prebuild` regenerates them):
```
pnpm install
pnpm --filter @solana/escrow-program-web build   # prebuild gen+build client, then tsc -b && vite build -> green
```