### PR TITLE
ci: publish only from main, drop hotfix/* release gate

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Guard allowed source branch for release publish
         run: |
           case "${{ github.ref }}" in
-            refs/heads/main|refs/heads/hotfix/*) ;;
+            refs/heads/main) ;;
             *)
-              echo "::error::Publish Rust Client must be run from main or hotfix/*. Current ref: ${{ github.ref }}"
+              echo "::error::Publish Rust Client must be run from main. Current ref: ${{ github.ref }}"
               exit 1
               ;;
           esac

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Guard allowed source branch for release publish
         run: |
           case "${{ github.ref }}" in
-            refs/heads/main|refs/heads/hotfix/*) ;;
+            refs/heads/main) ;;
             *)
-              echo "::error::Publish TypeScript Client must be run from main or hotfix/*. Current ref: ${{ github.ref }}"
+              echo "::error::Publish TypeScript Client must be run from main. Current ref: ${{ github.ref }}"
               exit 1
               ;;
           esac


### PR DESCRIPTION
Removes the `refs/heads/hotfix/*` allowance from both SDK publish workflows so official releases can only be dispatched from `main`. `hotfix/*` is not covered by branch protection, so a collaborator who can push such a branch could otherwise publish unreviewed code to the official crate/npm package.

Matches the same fix applied in the subscriptions repo.