### PR TITLE
ci: migrate github actions to solana-foundation org

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Report compute units
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: solana-developers/github-actions/cu-benchmark@e846103a578b3170a9a14824bcdf38d5dcf59ac0
+        uses: solana-foundation/github-actions/cu-benchmark@e846103a578b3170a9a14824bcdf38d5dcf59ac0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Report compute units
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: solana-foundation/github-actions/cu-benchmark@e846103a578b3170a9a14824bcdf38d5dcf59ac0
+        uses: solana-foundation/github-actions/cu-benchmark@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f # v0.2.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,13 @@ jobs:
         run: just generate-idl
 
       - name: Build verified program
-        uses: solana-foundation/github-actions/build-verified@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/build-verified@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f # v0.2.11
         with:
           program: ${{ env.PROGRAM }}
 
       - id: write-buffer
         name: Write program buffer
-        uses: solana-foundation/github-actions/write-program-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/write-program-buffer@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f # v0.2.11
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -88,7 +88,7 @@ jobs:
 
       - if: inputs.network == 'devnet'
         name: Upgrade program (devnet)
-        uses: solana-foundation/github-actions/program-upgrade@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/program-upgrade@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f # v0.2.11
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -98,7 +98,7 @@ jobs:
 
       - if: inputs.network == 'devnet'
         name: Upload IDL via program-metadata (devnet)
-        uses: solana-foundation/github-actions/metadata-upload@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/metadata-upload@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f # v0.2.11
         with:
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
@@ -108,7 +108,7 @@ jobs:
 
       - if: inputs.network == 'devnet'
         name: Verify build (devnet)
-        uses: solana-foundation/github-actions/verify-build@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/verify-build@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f # v0.2.11
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -122,7 +122,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: metadata-buffer
         name: Write IDL metadata buffer (mainnet)
-        uses: solana-foundation/github-actions/write-metadata-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/write-metadata-buffer@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f # v0.2.11
         with:
           idl-path: idl/escrow_program.json
           rpc-url: ${{ env.RPC_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,13 @@ jobs:
         run: just generate-idl
 
       - name: Build verified program
-        uses: solana-developers/github-actions/build-verified@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/build-verified@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
           program: ${{ env.PROGRAM }}
 
       - id: write-buffer
         name: Write program buffer
-        uses: solana-developers/github-actions/write-program-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/write-program-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -88,7 +88,7 @@ jobs:
 
       - if: inputs.network == 'devnet'
         name: Upgrade program (devnet)
-        uses: solana-developers/github-actions/program-upgrade@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/program-upgrade@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -98,7 +98,7 @@ jobs:
 
       - if: inputs.network == 'devnet'
         name: Upload IDL via program-metadata (devnet)
-        uses: solana-developers/github-actions/metadata-upload@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/metadata-upload@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
@@ -108,7 +108,7 @@ jobs:
 
       - if: inputs.network == 'devnet'
         name: Verify build (devnet)
-        uses: solana-developers/github-actions/verify-build@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/verify-build@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -122,7 +122,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: metadata-buffer
         name: Write IDL metadata buffer (mainnet)
-        uses: solana-developers/github-actions/write-metadata-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/write-metadata-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
           idl-path: idl/escrow_program.json
           rpc-url: ${{ env.RPC_URL }}


### PR DESCRIPTION
## Summary
- Migrate all GitHub Actions refs from `solana-developers/github-actions` to `solana-foundation/github-actions`
- `release.yml`: 6 actions (build-verified, write-program-buffer, program-upgrade, metadata-upload, verify-build, write-metadata-buffer)
- `benchmark.yml`: 1 action (cu-benchmark)
- SHA pins unchanged; both pinned commits (`eb60679`, `e846103`) verified present in the new repo

## Test Plan
- CI runs benchmark on this PR; release workflow is `workflow_dispatch`-only and unaffected by structure
- No `solana-developers/github-workflows` (reusable workflow) refs exist; nothing else to migrate