### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- Bump transitive dep `quinn-proto` 0.11.14 → 0.11.15 in `Cargo.lock`
- Fixes RUSTSEC-2026-0185 (remote memory exhaustion via unbounded out-of-order stream reassembly, CVSS 7.5 high) failing the `cargo audit` Security CI job on `main`
- Lockfile-only; patch bump within 0.11.x, no API change

## Test Plan
- `cargo audit` no longer reports a vulnerability