### PR TITLE
fix(ci): restore pnpm vulnerability audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,22 +47,5 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.62.0"
     },
-    "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
-    "pnpm": {
-        "overrides": {
-            "diff": ">=4.0.4",
-            "ajv@^6.0.0": "6.14.0",
-            "brace-expansion@^1.1.7": "1.1.13",
-            "flatted@^3.0.0": "3.4.2",
-            "handlebars@^4.0.0": "4.7.9",
-            "h3@^1.0.0": "1.15.9",
-            "lodash@^4.0.0": "4.17.23",
-            "minimatch@^3.0.0": "3.1.4",
-            "minimatch@^9.0.0": "9.0.7",
-            "picomatch@^2.0.0": "2.3.2",
-            "picomatch@^4.0.0": "4.0.4",
-            "socket.io-parser@^4.0.0": "4.2.6",
-            "ws@^8.0.0": "8.20.1"
-        }
-    }
+    "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,24 @@ packages:
   - 'clients/typescript'
   - 'apps/web'
   - 'examples/typescript/*'
+
+allowBuilds:
+  bufferutil: false
+  esbuild: true
+  unrs-resolver: true
+  utf-8-validate: false
+
+overrides:
+  diff: '>=4.0.4'
+  ajv@^6.0.0: 6.14.0
+  brace-expansion@^1.1.7: 1.1.13
+  flatted@^3.0.0: 3.4.2
+  handlebars@^4.0.0: 4.7.9
+  h3@^1.0.0: 1.15.9
+  lodash@^4.0.0: 4.17.23
+  minimatch@^3.0.0: 3.1.4
+  minimatch@^9.0.0: 9.0.7
+  picomatch@^2.0.0: 2.3.2
+  picomatch@^4.0.0: 4.0.4
+  socket.io-parser@^4.0.0: 4.2.6
+  ws@^8.0.0: 8.20.1


### PR DESCRIPTION
Pin pnpm 11 to use npm's bulk advisory endpoint and migrate workspace overrides to their supported configuration location. Define an explicit dependency build policy required by pnpm 11.

## Changes
- `package.json`: bump pnpm `10.15.1` → `11.13.0`; remove `pnpm.overrides` block (deprecated location).
- `pnpm-workspace.yaml`: relocate overrides here; add `allowBuilds` policy (pnpm 11 requirement).

## Build policy
Escrow's tree needs `esbuild` and `unrs-resolver` built (`true`); `bufferutil` and `utf-8-validate` are optional (`false`). Confirmed empirically — pnpm 11 built exactly those two and flagged no others.

## Verification
- `pnpm install --frozen-lockfile`: passes supply-chain policies, lockfile unchanged.
- `pnpm audit --ignore-unfixable`: exit 0.

Mirrors solana-foundation/subscriptions#208 (overrides differ — kept escrow's own).